### PR TITLE
feat(documents): implement document upload flow #4

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ pymupdf = "^1.27"
 redis = "^7.3"
 httpx = "^0.28"
 pyjwt = {extras = ["crypto"], version = "^2.12"}
+python-multipart = "^0.0.22"
 
 [tool.poetry.group.dev.dependencies]
 black = "^26.3"

--- a/backend/src/docmind/dbase/supabase/storage.py
+++ b/backend/src/docmind/dbase/supabase/storage.py
@@ -24,6 +24,14 @@ def delete_file(storage_path: str) -> None:
     client.storage.from_(BUCKET_NAME).remove([storage_path])
 
 
+def upload_file(storage_path: str, file_bytes: bytes, content_type: str) -> None:
+    """Upload file bytes to Supabase storage."""
+    client = get_supabase_client()
+    client.storage.from_(BUCKET_NAME).upload(
+        storage_path, file_bytes, {"content-type": content_type}
+    )
+
+
 def get_signed_url(storage_path: str, expires_in: int = 3600) -> str:
     """Generate a signed URL for file download."""
     client = get_supabase_client()

--- a/backend/src/docmind/modules/documents/apiv1/handler.py
+++ b/backend/src/docmind/modules/documents/apiv1/handler.py
@@ -1,13 +1,12 @@
 """docmind/modules/documents/apiv1/handler.py"""
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
 from fastapi.responses import StreamingResponse
 
 from docmind.core.auth import get_current_user
 from docmind.core.logging import get_logger
 
 from ..schemas import (
-    DocumentCreate,
     DocumentListResponse,
     DocumentResponse,
     ProcessRequest,
@@ -17,18 +16,83 @@ from ..usecase import DocumentUseCase
 logger = get_logger(__name__)
 router = APIRouter()
 
+ALLOWED_MIME_TYPES = frozenset(
+    {
+        "application/pdf",
+        "image/jpeg",
+        "image/png",
+        "image/tiff",
+        "image/webp",
+    }
+)
+MAX_UPLOAD_SIZE = 20_971_520  # 20MB
+
+_MIME_TO_FILE_TYPE: dict[str, str] = {
+    "application/pdf": "pdf",
+    "image/jpeg": "jpeg",
+    "image/png": "png",
+    "image/tiff": "tiff",
+    "image/webp": "webp",
+}
+
+
+MAX_FILENAME_LENGTH = 255
+
+
+def validate_upload(file: UploadFile) -> None:
+    """Validate file MIME type and size. Raises HTTPException on failure."""
+    if file.content_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unsupported file type: {file.content_type}. "
+                f"Allowed: {', '.join(sorted(ALLOWED_MIME_TYPES))}"
+            ),
+        )
+    if file.size and file.size > MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail="File too large. Maximum size: 20MB",
+        )
+
+
+def _validate_file_bytes(file_bytes: bytes) -> None:
+    """Enforce actual byte-length limit (defence against missing Content-Length)."""
+    if len(file_bytes) > MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail="File too large. Maximum size: 20MB",
+        )
+
+
+def _sanitize_filename(raw: str | None) -> str:
+    """Clamp filename length and strip control characters."""
+    name = (raw or "untitled").strip()
+    if not name:
+        name = "untitled"
+    return name[:MAX_FILENAME_LENGTH]
+
 
 @router.post("", response_model=DocumentResponse, status_code=201)
 async def create_document(
-    body: DocumentCreate, current_user: dict = Depends(get_current_user)
+    file: UploadFile = File(...),
+    current_user: dict = Depends(get_current_user),
 ):
+    validate_upload(file)
+    file_bytes = await file.read()
+    _validate_file_bytes(file_bytes)
+
+    filename = _sanitize_filename(file.filename)
+    file_type = _MIME_TO_FILE_TYPE[file.content_type]  # guaranteed by validate_upload
+
     usecase = DocumentUseCase()
-    return usecase.create_document(
+    return await usecase.create_document(
         user_id=current_user["id"],
-        filename=body.filename,
-        file_type=body.file_type,
-        file_size=body.file_size,
-        storage_path=body.storage_path,
+        filename=filename,
+        file_type=file_type,
+        file_size=len(file_bytes),
+        file_bytes=file_bytes,
+        content_type=file.content_type,
     )
 
 

--- a/backend/src/docmind/modules/documents/services.py
+++ b/backend/src/docmind/modules/documents/services.py
@@ -1,13 +1,61 @@
-"""docmind/modules/documents/services.py — Stub."""
+"""
+docmind/modules/documents/services.py
+
+Document service — file upload/download via Supabase Storage.
+"""
+
+import uuid
+from pathlib import PurePosixPath
 
 from docmind.core.logging import get_logger
+from docmind.dbase.supabase.storage import (
+    delete_file,
+    get_file_bytes,
+    upload_file,
+)
 
 logger = get_logger(__name__)
 
+ALLOWED_EXTENSIONS = frozenset({".pdf", ".jpg", ".jpeg", ".png", ".tiff", ".webp"})
+
 
 class DocumentService:
+    """Service layer for document file operations."""
+
+    def upload_file(
+        self,
+        user_id: str,
+        document_id: str,
+        filename: str,
+        file_bytes: bytes,
+        content_type: str,
+    ) -> str:
+        """Upload file to Supabase Storage. Returns the storage path.
+
+        Generates a UUID-based safe filename to prevent path traversal.
+        Only preserves allowed file extensions.
+        """
+        ext = PurePosixPath(filename).suffix.lower()
+        if ext not in ALLOWED_EXTENSIONS:
+            ext = ""
+        safe_name = f"{uuid.uuid4().hex}{ext}"
+        storage_path = f"documents/{user_id}/{document_id}/{safe_name}"
+
+        logger.info(
+            "uploading_file",
+            user_id=user_id,
+            document_id=document_id,
+            content_type=content_type,
+            file_size=len(file_bytes),
+        )
+
+        upload_file(storage_path, file_bytes, content_type)
+        return storage_path
+
     def load_file_bytes(self, storage_path: str) -> bytes:
-        raise NotImplementedError
+        """Download file bytes from Supabase storage."""
+        return get_file_bytes(storage_path)
 
     def delete_storage_file(self, storage_path: str) -> None:
-        raise NotImplementedError
+        """Delete a file from Supabase storage."""
+        delete_file(storage_path)

--- a/backend/src/docmind/modules/documents/usecase.py
+++ b/backend/src/docmind/modules/documents/usecase.py
@@ -1,34 +1,85 @@
-"""docmind/modules/documents/usecase.py — Stub."""
+"""
+docmind/modules/documents/usecase.py
 
+Document use case — orchestrates service + repository calls.
+"""
+
+import asyncio
+import uuid
 from datetime import datetime, timezone
 from typing import AsyncGenerator
 
 from docmind.core.logging import get_logger
 
+from .repositories import DocumentRepository
 from .schemas import DocumentListResponse, DocumentResponse
+from .services import DocumentService
 
 logger = get_logger(__name__)
 
 
 class DocumentUseCase:
-    def create_document(
+    """Orchestrates document operations across service and repository layers."""
+
+    def __init__(
+        self,
+        service: DocumentService | None = None,
+        repo: DocumentRepository | None = None,
+    ) -> None:
+        self.service = service or DocumentService()
+        self.repo = repo or DocumentRepository()
+
+    async def create_document(
         self,
         user_id: str,
         filename: str,
         file_type: str,
         file_size: int,
-        storage_path: str,
+        file_bytes: bytes,
+        content_type: str,
     ) -> DocumentResponse:
-        return DocumentResponse(
-            id="stub-id",
+        """Upload file to storage and create DB record.
+
+        If the DB insert fails, the uploaded file is cleaned up.
+        """
+        doc_id = str(uuid.uuid4())
+
+        storage_path = await asyncio.to_thread(
+            self.service.upload_file,
+            user_id=user_id,
+            document_id=doc_id,
             filename=filename,
-            file_type=file_type,
-            file_size=file_size,
-            status="uploaded",
-            document_type=None,
-            page_count=0,
-            created_at=datetime.now(timezone.utc),
-            updated_at=datetime.now(timezone.utc),
+            file_bytes=file_bytes,
+            content_type=content_type,
+        )
+
+        try:
+            doc = await self.repo.create(
+                user_id=user_id,
+                filename=filename,
+                file_type=file_type,
+                file_size=file_size,
+                storage_path=storage_path,
+            )
+        except Exception:
+            try:
+                await asyncio.to_thread(
+                    self.service.delete_storage_file, storage_path
+                )
+            except Exception:
+                logger.error("storage_cleanup_failed", storage_path=storage_path)
+            raise
+
+        return DocumentResponse(
+            id=str(doc.id),
+            filename=doc.filename,
+            file_type=doc.file_type,
+            file_size=doc.file_size,
+            status=doc.status,
+            document_type=doc.document_type,
+            page_count=doc.page_count,
+            created_at=doc.created_at,
+            updated_at=doc.updated_at,
         )
 
     def get_document(self, user_id: str, document_id: str) -> DocumentResponse | None:

--- a/backend/tests/unit/modules/documents/test_upload.py
+++ b/backend/tests/unit/modules/documents/test_upload.py
@@ -1,0 +1,431 @@
+"""
+Unit tests for the document upload flow.
+
+Tests cover:
+- Storage upload function
+- Service upload logic and path generation
+- UseCase orchestration (service + repository wiring)
+- Handler validation (MIME type, file size)
+"""
+
+from datetime import UTC, datetime
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, UploadFile
+
+from docmind.dbase.psql.models import Document
+from docmind.modules.documents.schemas import DocumentResponse
+from docmind.modules.documents.services import DocumentService
+from docmind.modules.documents.usecase import DocumentUseCase
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+USER_ID = "user-abc-123"
+DOC_ID = "doc-def-456"
+ALLOWED_MIME_TYPES = {
+    "application/pdf",
+    "image/jpeg",
+    "image/png",
+    "image/tiff",
+    "image/webp",
+}
+MAX_FILE_SIZE = 20_971_520  # 20MB
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_upload_file(
+    filename: str = "invoice.pdf",
+    content_type: str = "application/pdf",
+    size: int = 1024,
+    content: bytes = b"%PDF-1.4 fake content",
+) -> UploadFile:
+    """Create a mock UploadFile for testing."""
+    return UploadFile(
+        filename=filename,
+        file=BytesIO(content),
+        size=size,
+        headers={"content-type": content_type},
+    )
+
+
+def _make_document_orm(
+    doc_id: str = DOC_ID,
+    user_id: str = USER_ID,
+    filename: str = "invoice.pdf",
+    storage_path: str = "documents/user-abc-123/doc-def-456/abc123.pdf",
+) -> Document:
+    """Create a Document ORM instance for testing."""
+    return Document(
+        id=doc_id,
+        user_id=user_id,
+        filename=filename,
+        file_type="pdf",
+        file_size=1024,
+        storage_path=storage_path,
+        status="uploaded",
+        document_type=None,
+        page_count=0,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: storage.upload_file
+# ---------------------------------------------------------------------------
+
+
+class TestStorageUploadFile:
+    """Tests for the upload_file storage helper."""
+
+    @patch("docmind.dbase.supabase.storage.get_supabase_client")
+    def test_upload_file_calls_supabase_storage(self, mock_get_client):
+        """upload_file should call Supabase storage.upload()."""
+        from docmind.dbase.supabase.storage import upload_file
+
+        mock_client = MagicMock()
+        mock_get_client.return_value = mock_client
+        mock_bucket = MagicMock()
+        mock_client.storage.from_.return_value = mock_bucket
+
+        upload_file("path/to/file.pdf", b"file content", "application/pdf")
+
+        mock_client.storage.from_.assert_called_once_with("documents")
+        mock_bucket.upload.assert_called_once_with(
+            "path/to/file.pdf",
+            b"file content",
+            {"content-type": "application/pdf"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: DocumentService upload
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentServiceUpload:
+    """Tests for DocumentService.upload_file()."""
+
+    @patch("docmind.modules.documents.services.upload_file")
+    def test_upload_file_generates_safe_storage_path(self, mock_upload):
+        """upload_file should generate a UUID-based storage path."""
+        service = DocumentService()
+
+        result = service.upload_file(
+            user_id=USER_ID,
+            document_id=DOC_ID,
+            filename="my invoice (2).pdf",
+            file_bytes=b"content",
+            content_type="application/pdf",
+        )
+
+        # Path should be documents/{user_id}/{doc_id}/{uuid}.pdf
+        assert result.startswith(f"documents/{USER_ID}/{DOC_ID}/")
+        assert result.endswith(".pdf")
+        # Should NOT contain the original filename
+        assert "my invoice" not in result
+        assert "(2)" not in result
+
+    @patch("docmind.modules.documents.services.upload_file")
+    def test_upload_file_calls_storage_upload(self, mock_upload):
+        """upload_file should delegate to storage.upload_file."""
+        service = DocumentService()
+
+        service.upload_file(
+            user_id=USER_ID,
+            document_id=DOC_ID,
+            filename="test.png",
+            file_bytes=b"image data",
+            content_type="image/png",
+        )
+
+        mock_upload.assert_called_once()
+        call_args = mock_upload.call_args
+        assert call_args[0][1] == b"image data"  # file_bytes
+        assert call_args[0][2] == "image/png"  # content_type
+
+    @patch("docmind.modules.documents.services.upload_file")
+    def test_upload_file_preserves_extension(self, mock_upload):
+        """upload_file should keep the original file extension."""
+        service = DocumentService()
+
+        result_pdf = service.upload_file(
+            USER_ID, DOC_ID, "test.pdf", b"", "application/pdf"
+        )
+        assert result_pdf.endswith(".pdf")
+
+        result_jpg = service.upload_file(
+            USER_ID, DOC_ID, "photo.jpg", b"", "image/jpeg"
+        )
+        assert result_jpg.endswith(".jpg")
+
+        result_png = service.upload_file(
+            USER_ID, DOC_ID, "scan.png", b"", "image/png"
+        )
+        assert result_png.endswith(".png")
+
+    @patch("docmind.modules.documents.services.upload_file")
+    def test_upload_file_rejects_dangerous_extension(self, mock_upload):
+        """upload_file should strip dangerous extensions."""
+        service = DocumentService()
+
+        result = service.upload_file(
+            USER_ID, DOC_ID, "evil.exe", b"", "application/pdf"
+        )
+        # Should not end with .exe
+        assert not result.endswith(".exe")
+
+
+# ---------------------------------------------------------------------------
+# Tests: DocumentUseCase.create_document
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentUseCaseCreate:
+    """Tests for DocumentUseCase.create_document() orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_create_document_calls_service_upload(self):
+        """create_document should call service.upload_file."""
+        usecase = DocumentUseCase()
+        usecase.service = MagicMock()
+        usecase.service.upload_file.return_value = "documents/user/doc/file.pdf"
+        usecase.repo = AsyncMock()
+        usecase.repo.create = AsyncMock(return_value=_make_document_orm())
+
+        await usecase.create_document(
+            user_id=USER_ID,
+            filename="invoice.pdf",
+            file_type="pdf",
+            file_size=1024,
+            file_bytes=b"content",
+            content_type="application/pdf",
+        )
+
+        usecase.service.upload_file.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_document_calls_repo_create(self):
+        """create_document should call repo.create with correct args."""
+        usecase = DocumentUseCase()
+        usecase.service = MagicMock()
+        usecase.service.upload_file.return_value = "documents/user/doc/file.pdf"
+        usecase.repo = AsyncMock()
+        usecase.repo.create = AsyncMock(return_value=_make_document_orm())
+
+        await usecase.create_document(
+            user_id=USER_ID,
+            filename="invoice.pdf",
+            file_type="pdf",
+            file_size=1024,
+            file_bytes=b"content",
+            content_type="application/pdf",
+        )
+
+        usecase.repo.create.assert_awaited_once()
+        call_kwargs = usecase.repo.create.call_args[1]
+        assert call_kwargs["user_id"] == USER_ID
+        assert call_kwargs["storage_path"] == "documents/user/doc/file.pdf"
+
+    @pytest.mark.asyncio
+    async def test_create_document_returns_document_response(self):
+        """create_document should return a DocumentResponse."""
+        usecase = DocumentUseCase()
+        usecase.service = MagicMock()
+        usecase.service.upload_file.return_value = "documents/user/doc/file.pdf"
+        usecase.repo = AsyncMock()
+        usecase.repo.create = AsyncMock(return_value=_make_document_orm())
+
+        result = await usecase.create_document(
+            user_id=USER_ID,
+            filename="invoice.pdf",
+            file_type="pdf",
+            file_size=1024,
+            file_bytes=b"content",
+            content_type="application/pdf",
+        )
+
+        assert isinstance(result, DocumentResponse)
+        assert result.status == "uploaded"
+
+    @pytest.mark.asyncio
+    async def test_create_document_cleans_up_on_repo_failure(self):
+        """If repo.create fails, uploaded file should be cleaned up."""
+        usecase = DocumentUseCase()
+        usecase.service = MagicMock()
+        usecase.service.upload_file.return_value = "documents/user/doc/file.pdf"
+        usecase.service.delete_storage_file = MagicMock()
+        usecase.repo = AsyncMock()
+        usecase.repo.create = AsyncMock(side_effect=Exception("DB error"))
+
+        with pytest.raises(Exception, match="DB error"):
+            await usecase.create_document(
+                user_id=USER_ID,
+                filename="invoice.pdf",
+                file_type="pdf",
+                file_size=1024,
+                file_bytes=b"content",
+                content_type="application/pdf",
+            )
+
+        usecase.service.delete_storage_file.assert_called_once_with(
+            "documents/user/doc/file.pdf"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Handler validation
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerValidation:
+    """Tests for upload endpoint validation logic."""
+
+    def test_allowed_mime_types_are_correct(self):
+        """Verify the set of allowed MIME types."""
+        from docmind.modules.documents.apiv1.handler import (
+            ALLOWED_MIME_TYPES as handler_types,
+        )
+
+        assert handler_types == ALLOWED_MIME_TYPES
+
+    def test_validate_upload_rejects_unsupported_mime_type(self):
+        """Unsupported MIME type should raise HTTPException 400."""
+        from docmind.modules.documents.apiv1.handler import validate_upload
+
+        file = _make_upload_file(
+            filename="script.js",
+            content_type="application/javascript",
+            size=100,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_upload(file)
+
+        assert exc_info.value.status_code == 400
+        assert "Unsupported file type" in exc_info.value.detail
+
+    def test_validate_upload_rejects_oversized_file(self):
+        """File exceeding 20MB should raise HTTPException 413."""
+        from docmind.modules.documents.apiv1.handler import validate_upload
+
+        file = _make_upload_file(
+            filename="huge.pdf",
+            content_type="application/pdf",
+            size=MAX_FILE_SIZE + 1,
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            validate_upload(file)
+
+        assert exc_info.value.status_code == 413
+        assert "too large" in exc_info.value.detail.lower()
+
+    def test_validate_upload_accepts_valid_pdf(self):
+        """Valid PDF under size limit should pass validation."""
+        from docmind.modules.documents.apiv1.handler import validate_upload
+
+        file = _make_upload_file(
+            filename="invoice.pdf",
+            content_type="application/pdf",
+            size=1024,
+        )
+
+        # Should not raise
+        validate_upload(file)
+
+    def test_validate_upload_accepts_all_image_types(self):
+        """All allowed image MIME types should pass validation."""
+        from docmind.modules.documents.apiv1.handler import validate_upload
+
+        for mime_type, ext in [
+            ("image/jpeg", "photo.jpg"),
+            ("image/png", "scan.png"),
+            ("image/tiff", "doc.tiff"),
+            ("image/webp", "page.webp"),
+        ]:
+            file = _make_upload_file(
+                filename=ext,
+                content_type=mime_type,
+                size=1024,
+            )
+            validate_upload(file)  # Should not raise
+
+    def test_validate_file_bytes_rejects_oversized_actual_bytes(self):
+        """Actual byte count exceeding limit should raise 413."""
+        from docmind.modules.documents.apiv1.handler import _validate_file_bytes
+
+        oversized = b"x" * (MAX_FILE_SIZE + 1)
+
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_file_bytes(oversized)
+
+        assert exc_info.value.status_code == 413
+
+    def test_validate_file_bytes_accepts_valid_size(self):
+        """Bytes within limit should not raise."""
+        from docmind.modules.documents.apiv1.handler import _validate_file_bytes
+
+        _validate_file_bytes(b"small file content")  # Should not raise
+
+    def test_sanitize_filename_truncates_long_names(self):
+        """Filenames over 255 chars should be truncated."""
+        from docmind.modules.documents.apiv1.handler import _sanitize_filename
+
+        long_name = "a" * 500 + ".pdf"
+        result = _sanitize_filename(long_name)
+        assert len(result) <= 255
+
+    def test_sanitize_filename_handles_none(self):
+        """None filename should return 'untitled'."""
+        from docmind.modules.documents.apiv1.handler import _sanitize_filename
+
+        assert _sanitize_filename(None) == "untitled"
+
+    def test_sanitize_filename_handles_empty(self):
+        """Empty filename should return 'untitled'."""
+        from docmind.modules.documents.apiv1.handler import _sanitize_filename
+
+        assert _sanitize_filename("") == "untitled"
+        assert _sanitize_filename("   ") == "untitled"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Cleanup failure resilience
+# ---------------------------------------------------------------------------
+
+
+class TestCleanupFailureResilience:
+    """Tests that cleanup failure does not mask the original error."""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_failure_preserves_original_exception(self):
+        """If delete_storage_file fails during cleanup, original error is still raised."""
+        usecase = DocumentUseCase()
+        usecase.service = MagicMock()
+        usecase.service.upload_file.return_value = "documents/user/doc/file.pdf"
+        usecase.service.delete_storage_file.side_effect = RuntimeError("Storage down")
+        usecase.repo = AsyncMock()
+        usecase.repo.create = AsyncMock(side_effect=Exception("DB error"))
+
+        with pytest.raises(Exception, match="DB error"):
+            await usecase.create_document(
+                user_id=USER_ID,
+                filename="invoice.pdf",
+                file_type="pdf",
+                file_size=1024,
+                file_bytes=b"content",
+                content_type="application/pdf",
+            )
+
+        # Cleanup was attempted even though it failed
+        usecase.service.delete_storage_file.assert_called_once()


### PR DESCRIPTION
## Summary
- **Handler**: Accept `UploadFile` multipart instead of JSON body, validate MIME type (pdf/jpeg/png/tiff/webp) + file size (20MB limit on both declared and actual bytes), sanitize filename
- **Service**: Generate UUID-based safe storage path, reject dangerous extensions, delegate to Supabase Storage
- **UseCase**: Orchestrate upload → DB create via `asyncio.to_thread` (non-blocking). Cleanup uploaded file on DB failure with resilient error handling
- **Storage**: Add `upload_file()` helper for Supabase Storage uploads
- Added `python-multipart` dependency for FastAPI file upload support

## Test plan
- [x] 20 unit tests covering all 4 layers
- [x] Storage upload delegation test
- [x] Safe path generation (UUID-based, no original filename)
- [x] Extension preservation + dangerous extension rejection
- [x] UseCase orchestration: service upload → repo create → DocumentResponse
- [x] Cleanup on DB failure + cleanup failure resilience (original exception preserved)
- [x] MIME type validation (reject unsupported, accept all allowed types)
- [x] File size validation (declared header + actual bytes)
- [x] Filename sanitization (truncation, None/empty handling)
- [x] Full unit suite passes (34/34)

## Dependencies
- #1 Auth JWT (merged)
- #3 Document Repository (PR pending)