### PR TITLE
feat(health): implement real health checks #5

### DIFF
--- a/backend/src/docmind/modules/health/apiv1/handler.py
+++ b/backend/src/docmind/modules/health/apiv1/handler.py
@@ -20,7 +20,7 @@ async def ping():
 @router.get("/status", response_model=HealthStatusResponse)
 async def get_health_status():
     usecase = HealthUseCase()
-    overall_status, components, uptime = usecase.get_basic_health()
+    overall_status, components, uptime = await usecase.get_basic_health()
     return HealthStatusResponse(
         status=overall_status,
         timestamp=datetime.now(timezone.utc),

--- a/backend/src/docmind/modules/health/usecase.py
+++ b/backend/src/docmind/modules/health/usecase.py
@@ -1,22 +1,121 @@
-"""docmind/modules/health/usecase.py"""
+"""
+docmind/modules/health/usecase.py
+
+Health check orchestration — checks DB, Redis, VLM provider.
+"""
 
 import time
 
+from redis.asyncio import from_url as redis_from_url
+from sqlalchemy import text
+
+from docmind.core.config import get_settings
+from docmind.core.logging import get_logger
+from docmind.dbase.psql.core.session import AsyncSessionLocal
+
 from .schemas import ComponentHealth
+
+logger = get_logger(__name__)
 
 _start_time = time.time()
 
+_VLM_API_KEY_MAP: dict[str, str | None] = {
+    "dashscope": "DASHSCOPE_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "ollama": None,
+}
+
 
 class HealthUseCase:
-    def get_basic_health(self) -> tuple[str, list[ComponentHealth], float]:
-        components = [
-            ComponentHealth(
-                name="database", status="healthy", message="Stub — not connected"
-            ),
-            ComponentHealth(
-                name="vlm_provider", status="healthy", message="Stub — not connected"
-            ),
-        ]
-        overall = "healthy"
+    """Orchestrates health checks for all system components."""
+
+    async def get_basic_health(self) -> tuple[str, list[ComponentHealth], float]:
+        """Check all components and return (overall_status, components, uptime_seconds)."""
+        components: list[ComponentHealth] = []
+
+        components.append(await self._check_database())
+        components.append(await self._check_redis())
+        components.append(self._check_vlm_provider())
+
+        overall = (
+            "healthy"
+            if all(c.status == "healthy" for c in components)
+            else "degraded"
+        )
         uptime = time.time() - _start_time
+
         return overall, components, uptime
+
+    async def _check_database(self) -> ComponentHealth:
+        """Check database connectivity via SQLAlchemy SELECT 1."""
+        try:
+            t0 = time.time()
+            async with AsyncSessionLocal() as session:
+                await session.execute(text("SELECT 1"))
+            ms = (time.time() - t0) * 1000
+            return ComponentHealth(
+                name="database",
+                status="healthy",
+                message="Connected",
+                response_time_ms=round(ms, 1),
+            )
+        except Exception as e:
+            logger.warning("database_health_check_failed", error=str(e))
+            return ComponentHealth(
+                name="database",
+                status="unhealthy",
+                message=str(e),
+            )
+
+    async def _check_redis(self) -> ComponentHealth:
+        """Check Redis connectivity via PING."""
+        settings = get_settings()
+        try:
+            t0 = time.time()
+            client = redis_from_url(settings.REDIS_URL)
+            try:
+                await client.ping()
+                ms = (time.time() - t0) * 1000
+                return ComponentHealth(
+                    name="redis",
+                    status="healthy",
+                    message="Connected",
+                    response_time_ms=round(ms, 1),
+                )
+            finally:
+                await client.aclose()
+        except Exception as e:
+            logger.warning("redis_health_check_failed", error=str(e))
+            return ComponentHealth(
+                name="redis",
+                status="unhealthy",
+                message=str(e),
+            )
+
+    def _check_vlm_provider(self) -> ComponentHealth:
+        """Check VLM provider configuration (no API call)."""
+        settings = get_settings()
+        provider = settings.VLM_PROVIDER
+        api_key_attr = _VLM_API_KEY_MAP.get(provider)
+
+        if api_key_attr is None:
+            return ComponentHealth(
+                name="vlm_provider",
+                status="healthy",
+                message=f"{provider} (local)",
+            )
+
+        api_key = getattr(settings, api_key_attr, "")
+        if api_key:
+            return ComponentHealth(
+                name="vlm_provider",
+                status="healthy",
+                message=f"{provider} configured",
+            )
+
+        return ComponentHealth(
+            name="vlm_provider",
+            status="unhealthy",
+            message=f"{provider} API key not configured",
+        )

--- a/backend/tests/unit/modules/health/test_usecase.py
+++ b/backend/tests/unit/modules/health/test_usecase.py
@@ -1,0 +1,388 @@
+"""
+Unit tests for docmind/modules/health/usecase.py.
+
+Tests cover:
+- All components healthy
+- Database down
+- Redis down
+- VLM provider not configured
+- Uptime tracking
+- Response time measurement
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from docmind.modules.health.usecase import HealthUseCase
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def usecase():
+    return HealthUseCase()
+
+
+@pytest.fixture
+def mock_db_healthy():
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.fixture
+def mock_db_unhealthy():
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=ConnectionRefusedError("Connection refused")
+    )
+    cm = AsyncMock()
+    cm.__aenter__ = AsyncMock(return_value=session)
+    cm.__aexit__ = AsyncMock(return_value=False)
+    return cm
+
+
+@pytest.fixture
+def mock_redis_healthy():
+    redis_client = AsyncMock()
+    redis_client.ping = AsyncMock(return_value=True)
+    redis_client.aclose = AsyncMock()
+    return redis_client
+
+
+@pytest.fixture
+def mock_redis_unhealthy():
+    redis_client = AsyncMock()
+    redis_client.ping = AsyncMock(
+        side_effect=ConnectionError("Redis not available")
+    )
+    redis_client.aclose = AsyncMock()
+    return redis_client
+
+
+@pytest.fixture
+def mock_settings_with_vlm():
+    settings = MagicMock()
+    settings.VLM_PROVIDER = "dashscope"
+    settings.DASHSCOPE_API_KEY = "sk-test-key"
+    settings.OPENAI_API_KEY = ""
+    settings.GOOGLE_API_KEY = ""
+    settings.REDIS_URL = "redis://localhost:6379/0"
+    return settings
+
+
+@pytest.fixture
+def mock_settings_no_vlm():
+    settings = MagicMock()
+    settings.VLM_PROVIDER = "dashscope"
+    settings.DASHSCOPE_API_KEY = ""
+    settings.OPENAI_API_KEY = ""
+    settings.GOOGLE_API_KEY = ""
+    settings.REDIS_URL = "redis://localhost:6379/0"
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# Tests: All Healthy
+# ---------------------------------------------------------------------------
+
+
+class TestAllHealthy:
+    """Tests when all components are healthy."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_all_healthy_returns_healthy_status(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_healthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        overall, components, uptime = await usecase.get_basic_health()
+
+        assert overall == "healthy"
+        assert all(c.status == "healthy" for c in components)
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_all_healthy_returns_three_components(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_healthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        _, components, _ = await usecase.get_basic_health()
+
+        component_names = {c.name for c in components}
+        assert "database" in component_names
+        assert "redis" in component_names
+        assert "vlm_provider" in component_names
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_healthy_db_includes_response_time(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_healthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        _, components, _ = await usecase.get_basic_health()
+
+        db_component = next(c for c in components if c.name == "database")
+        assert db_component.response_time_ms is not None
+        assert db_component.response_time_ms >= 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Database Down
+# ---------------------------------------------------------------------------
+
+
+class TestDatabaseDown:
+    """Tests when the database is unhealthy."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_db_down_returns_degraded(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_unhealthy,
+        mock_redis_healthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_unhealthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        overall, components, _ = await usecase.get_basic_health()
+
+        assert overall == "degraded"
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_db_down_reports_unhealthy_component(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_unhealthy,
+        mock_redis_healthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_unhealthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        _, components, _ = await usecase.get_basic_health()
+
+        db_component = next(c for c in components if c.name == "database")
+        assert db_component.status == "unhealthy"
+        assert db_component.message is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Redis Down
+# ---------------------------------------------------------------------------
+
+
+class TestRedisDown:
+    """Tests when Redis is unhealthy."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_redis_down_returns_degraded(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_unhealthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_unhealthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        overall, components, _ = await usecase.get_basic_health()
+
+        assert overall == "degraded"
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_redis_down_reports_unhealthy_component(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_unhealthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_unhealthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        _, components, _ = await usecase.get_basic_health()
+
+        redis_component = next(c for c in components if c.name == "redis")
+        assert redis_component.status == "unhealthy"
+        assert redis_component.message is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests: VLM Provider Not Configured
+# ---------------------------------------------------------------------------
+
+
+class TestVlmProviderDown:
+    """Tests when VLM provider is not configured."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_vlm_not_configured_returns_degraded(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_healthy,
+        mock_settings_no_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_no_vlm
+
+        overall, components, _ = await usecase.get_basic_health()
+
+        assert overall == "degraded"
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_vlm_not_configured_reports_unhealthy(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_healthy,
+        mock_settings_no_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_no_vlm
+
+        _, components, _ = await usecase.get_basic_health()
+
+        vlm_component = next(c for c in components if c.name == "vlm_provider")
+        assert vlm_component.status == "unhealthy"
+        assert "not configured" in vlm_component.message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: Uptime
+# ---------------------------------------------------------------------------
+
+
+class TestUptime:
+    """Tests for uptime tracking."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_uptime_is_positive(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_healthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        _, _, uptime = await usecase.get_basic_health()
+
+        assert uptime > 0
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.health.usecase.get_settings")
+    @patch("docmind.modules.health.usecase.redis_from_url")
+    @patch("docmind.modules.health.usecase.AsyncSessionLocal")
+    async def test_uptime_is_float(
+        self,
+        mock_async_session_local,
+        mock_redis_from_url,
+        mock_get_settings,
+        usecase,
+        mock_db_healthy,
+        mock_redis_healthy,
+        mock_settings_with_vlm,
+    ):
+        mock_async_session_local.return_value = mock_db_healthy
+        mock_redis_from_url.return_value = mock_redis_healthy
+        mock_get_settings.return_value = mock_settings_with_vlm
+
+        _, _, uptime = await usecase.get_basic_health()
+
+        assert isinstance(uptime, float)


### PR DESCRIPTION
## Summary
- Replace stub `HealthUseCase` with real async health checks
- **Database**: `SELECT 1` via SQLAlchemy async session, reports response time in ms
- **Redis**: `PING` via `redis.asyncio`, reports response time, client always closed via `try/finally`
- **VLM provider**: Configuration validation (API key check per provider), no external calls
- Overall status: `"healthy"` when all pass, `"degraded"` when any fail
- All exceptions caught and reported as `"unhealthy"` with message (no stack traces)
- Handler updated to `await` the async usecase call

## Test plan
- [x] 11 unit tests covering all scenarios
- [x] All healthy: correct status, 3 components, response time present
- [x] DB down: degraded status, unhealthy component with message
- [x] Redis down: degraded status, unhealthy component with message
- [x] VLM not configured: degraded status, "not configured" in message
- [x] Uptime: positive float
- [x] Full unit suite passes (25/25)

## Dependencies
- #2 Alembic migration (merged)