### PR TITLE
feat(providers): implement DashScope VLM provider #9

### DIFF
--- a/backend/src/docmind/library/providers/dashscope.py
+++ b/backend/src/docmind/library/providers/dashscope.py
@@ -2,50 +2,142 @@
 docmind/library/providers/dashscope.py
 
 DashScope (Alibaba Cloud) VLM provider for Qwen-VL models.
+
+This is the primary provider for DocMind-VLM. Uses the DashScope
+multimodal conversation API with base64-encoded images.
 """
 
+import json
 import logging
+import time
+from typing import Any
 
 import httpx
 import numpy as np
 
 from docmind.core.config import get_settings
-from docmind.library.providers.protocol import VLMResponse
+from docmind.library.providers.protocol import VLMResponse, encode_image_base64
 
 logger = logging.getLogger(__name__)
+
 BASE_URL = "https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"
 DEFAULT_MODEL = "qwen-vl-max"
 MAX_RETRIES = 3
-RETRY_BASE_DELAY = 2.0
-REQUEST_TIMEOUT = 120.0
+RETRY_BASE_DELAY = 2.0  # seconds, doubles each retry
+REQUEST_TIMEOUT = 120.0  # seconds
 
 
 class DashScopeProvider:
+    """DashScope VLM provider using Qwen-VL models.
+
+    Requires DASHSCOPE_API_KEY environment variable.
+    """
+
     def __init__(self) -> None:
+        """Initialize the DashScope provider.
+
+        Raises:
+            RuntimeError: If DASHSCOPE_API_KEY is not set.
+        """
         settings = get_settings()
         self._api_key = settings.DASHSCOPE_API_KEY
         if not self._api_key:
             raise RuntimeError(
-                "DASHSCOPE_API_KEY is required" " when VLM_PROVIDER=dashscope"
+                "DASHSCOPE_API_KEY is required when VLM_PROVIDER=dashscope"
             )
         self._model = settings.DASHSCOPE_MODEL or DEFAULT_MODEL
         self._client = httpx.AsyncClient(timeout=REQUEST_TIMEOUT)
 
     @property
     def provider_name(self) -> str:
+        """Human-readable provider name."""
         return "DashScope"
 
     @property
     def model_name(self) -> str:
+        """Model identifier string."""
         return self._model
 
     async def extract(
-        self, images: list[np.ndarray], prompt: str, schema: dict | None = None
+        self,
+        images: list[np.ndarray],
+        prompt: str,
+        schema: dict | None = None,
     ) -> VLMResponse:
-        raise NotImplementedError("DashScope extract not yet implemented in scaffold")
+        """Extract structured data from document images.
 
-    async def classify(self, image: np.ndarray, categories: list[str]) -> VLMResponse:
-        raise NotImplementedError("DashScope classify not yet implemented in scaffold")
+        Constructs a multimodal payload with all page images and the
+        extraction prompt. If a schema is provided, it is included in
+        the prompt to guide structured output.
+
+        Args:
+            images: List of BGR uint8 page images.
+            prompt: Extraction prompt.
+            schema: Optional JSON schema for structured output.
+
+        Returns:
+            VLMResponse with extracted fields in structured_data.
+        """
+        image_contents = [
+            {"image": f"data:image/jpeg;base64,{encode_image_base64(img)}"}
+            for img in images
+        ]
+
+        extraction_prompt = prompt
+        if schema is not None:
+            extraction_prompt += (
+                "\n\nRespond with valid JSON matching this schema:\n"
+                f"```json\n{json.dumps(schema, indent=2)}\n```"
+            )
+
+        user_content = image_contents + [{"text": extraction_prompt}]
+
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "system",
+                "content": [{"text": (
+                    "You are a document extraction assistant. Extract all requested "
+                    "information from the provided document images. Return structured "
+                    "JSON. If a field is not visible or legible, set its value to null "
+                    "and set confidence to 0.0."
+                )}],
+            },
+            {"role": "user", "content": user_content},
+        ]
+
+        return await self._call_api(messages)
+
+    async def classify(
+        self,
+        image: np.ndarray,
+        categories: list[str],
+    ) -> VLMResponse:
+        """Classify document type from first page.
+
+        Args:
+            image: First page of the document (BGR uint8).
+            categories: List of valid document type strings.
+
+        Returns:
+            VLMResponse with classification in structured_data.
+        """
+        categories_str = ", ".join(categories)
+        prompt = (
+            f"Classify this document into one of these categories: {categories_str}.\n"
+            'Respond with JSON: {"document_type": "<category>", "confidence": <0.0-1.0>}'
+        )
+
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": [
+                    {"image": f"data:image/jpeg;base64,{encode_image_base64(image)}"},
+                    {"text": prompt},
+                ],
+            },
+        ]
+
+        return await self._call_api(messages)
 
     async def chat(
         self,
@@ -54,20 +146,66 @@ class DashScopeProvider:
         history: list[dict],
         system_prompt: str,
     ) -> VLMResponse:
-        raise NotImplementedError("DashScope chat not yet implemented in scaffold")
+        """Chat about document content with conversation history.
+
+        Images are included in the first user message for visual grounding.
+        With no history, images accompany the current message. With history,
+        images are attached to the first historical user message.
+
+        Args:
+            images: Document page images for visual grounding.
+            message: Current user message.
+            history: Previous messages as [{"role": str, "content": str}, ...].
+            system_prompt: System prompt enforcing grounding rules.
+
+        Returns:
+            VLMResponse with answer in content.
+        """
+        image_contents = [
+            {"image": f"data:image/jpeg;base64,{encode_image_base64(img)}"}
+            for img in images
+        ]
+
+        messages: list[dict[str, Any]] = [
+            {"role": "system", "content": [{"text": system_prompt}]},
+        ]
+
+        if history:
+            # First user message includes images for grounding
+            first_user_content = image_contents + [{"text": history[0]["content"]}]
+            messages.append({"role": "user", "content": first_user_content})
+
+            for msg in history[1:]:
+                messages.append({
+                    "role": msg["role"],
+                    "content": [{"text": msg["content"]}],
+                })
+
+            # Append current message
+            messages.append({"role": "user", "content": [{"text": message}]})
+        else:
+            # No history — include images with current message
+            current_content = image_contents + [{"text": message}]
+            messages.append({"role": "user", "content": current_content})
+
+        return await self._call_api(messages)
 
     async def health_check(self) -> bool:
+        """Check DashScope API connectivity.
+
+        Returns:
+            True if API is reachable (200 or 400), False otherwise.
+        """
         try:
             response = await self._client.post(
                 BASE_URL,
-                headers={
-                    "Authorization": f"Bearer {self._api_key}",
-                    "Content-Type": "application/json",
-                },
+                headers=self._build_headers(),
                 json={
                     "model": self._model,
                     "input": {
-                        "messages": [{"role": "user", "content": [{"text": "ping"}]}]
+                        "messages": [
+                            {"role": "user", "content": [{"text": "ping"}]},
+                        ],
                     },
                     "parameters": {"max_tokens": 1},
                 },
@@ -76,3 +214,144 @@ class DashScopeProvider:
         except Exception as e:
             logger.warning("DashScope health check failed: %s", e)
             return False
+
+    def _build_headers(self) -> dict[str, str]:
+        """Build request headers with auth."""
+        return {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def _build_payload(self, messages: list[dict]) -> dict:
+        """Build the DashScope multimodal API payload.
+
+        Args:
+            messages: List of message dicts in DashScope format.
+
+        Returns:
+            Complete API payload dict.
+        """
+        return {
+            "model": self._model,
+            "input": {"messages": messages},
+            "parameters": {
+                "max_tokens": 4096,
+                "temperature": 0.1,
+                "result_format": "message",
+            },
+        }
+
+    async def _call_api(self, messages: list[dict]) -> VLMResponse:
+        """Call the DashScope API with retry and exponential backoff.
+
+        Retries on 429 rate limit and transient network errors.
+        Raises immediately on other HTTP errors (4xx, 5xx).
+
+        Args:
+            messages: List of message dicts in DashScope format.
+
+        Returns:
+            Parsed VLMResponse.
+
+        Raises:
+            RuntimeError: On non-retryable HTTP errors or after all retries exhausted.
+        """
+        payload = self._build_payload(messages)
+        headers = self._build_headers()
+        last_error: Exception | None = None
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                response = await self._client.post(
+                    BASE_URL,
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+                return self._parse_response(response.json())
+
+            except httpx.HTTPStatusError as e:
+                last_error = e
+                if e.response.status_code == 429:
+                    wait = RETRY_BASE_DELAY * (2 ** attempt)
+                    logger.warning(
+                        "DashScope rate limited. Waiting %.1fs (attempt %d/%d)",
+                        wait, attempt + 1, MAX_RETRIES,
+                    )
+                    time.sleep(wait)
+                    continue
+                logger.error(
+                    "DashScope API error: %d", e.response.status_code
+                )
+                raise RuntimeError(
+                    f"DashScope API error: {e.response.status_code}"
+                ) from e
+
+            except httpx.RequestError as e:
+                last_error = e
+                wait = RETRY_BASE_DELAY * (2 ** attempt)
+                logger.warning(
+                    "DashScope request error: %s. Retrying in %.1fs (attempt %d/%d)",
+                    e, wait, attempt + 1, MAX_RETRIES,
+                )
+                time.sleep(wait)
+
+        raise RuntimeError(
+            f"DashScope API failed after {MAX_RETRIES} retries"
+        ) from last_error
+
+    def _parse_response(self, raw: dict) -> VLMResponse:
+        """Parse DashScope API response into VLMResponse.
+
+        Handles JSON content, markdown-wrapped JSON, and plain text fallback.
+
+        Args:
+            raw: Raw API response dict.
+
+        Returns:
+            Parsed VLMResponse with structured_data and confidence.
+        """
+        output = raw.get("output", {})
+        choices = output.get("choices", [])
+        if not choices:
+            logger.warning("DashScope response contained no choices")
+        message = choices[0].get("message", {}) if choices else {}
+        content = ""
+
+        # Handle multimodal content format
+        raw_content = message.get("content", "")
+        if isinstance(raw_content, list):
+            content = " ".join(
+                item.get("text", "") for item in raw_content if "text" in item
+            )
+        else:
+            content = str(raw_content)
+
+        # Try to parse JSON from content
+        structured_data: dict = {}
+        confidence = 0.0
+        try:
+            text = content.strip()
+            if text.startswith("```"):
+                text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+                text = text.rsplit("```", 1)[0]
+            structured_data = json.loads(text)
+            raw_confidence = structured_data.get("confidence", 0.8)
+            confidence = max(0.0, min(1.0, float(raw_confidence)))
+        except (json.JSONDecodeError, IndexError):
+            structured_data = {"raw_text": content}
+            confidence = 0.5
+
+        usage = raw.get("usage", {})
+
+        return VLMResponse(
+            content=content,
+            structured_data=structured_data,
+            confidence=float(confidence),
+            model=self._model,
+            usage={
+                "input_tokens": usage.get("input_tokens", 0),
+                "output_tokens": usage.get("output_tokens", 0),
+            },
+            raw_response=raw,
+        )

--- a/backend/tests/unit/library/providers/test_dashscope.py
+++ b/backend/tests/unit/library/providers/test_dashscope.py
@@ -1,0 +1,698 @@
+"""
+Tests for docmind.library.providers.dashscope module.
+
+All DashScope API calls are mocked — no real API calls.
+Tests verify request construction, response parsing, retry logic,
+and error handling.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import numpy as np
+import pytest
+
+from docmind.library.providers.dashscope import (
+    BASE_URL,
+    DEFAULT_MODEL,
+    MAX_RETRIES,
+    RETRY_BASE_DELAY,
+    DashScopeProvider,
+)
+from docmind.library.providers.protocol import VLMResponse
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_settings():
+    """Mock settings with valid DashScope config."""
+    settings = MagicMock()
+    settings.DASHSCOPE_API_KEY = "test-api-key-12345"
+    settings.DASHSCOPE_MODEL = "qwen-vl-max"
+    return settings
+
+
+@pytest.fixture
+def provider(mock_settings) -> DashScopeProvider:
+    """Create a DashScopeProvider with mocked settings."""
+    with patch("docmind.library.providers.dashscope.get_settings", return_value=mock_settings):
+        return DashScopeProvider()
+
+
+@pytest.fixture
+def sample_image() -> np.ndarray:
+    """Small BGR test image."""
+    return np.zeros((100, 100, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def sample_images(sample_image: np.ndarray) -> list[np.ndarray]:
+    """List of test images (2 pages)."""
+    return [sample_image, sample_image.copy()]
+
+
+@pytest.fixture
+def successful_extract_response() -> dict:
+    """Mock DashScope API response for extraction."""
+    return {
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": json.dumps({
+                                    "invoice_number": "INV-001",
+                                    "total": 150.00,
+                                    "confidence": 0.95,
+                                })
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        "usage": {
+            "input_tokens": 500,
+            "output_tokens": 100,
+        },
+    }
+
+
+@pytest.fixture
+def successful_classify_response() -> dict:
+    """Mock DashScope API response for classification."""
+    return {
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": json.dumps({
+                                    "document_type": "invoice",
+                                    "confidence": 0.92,
+                                })
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        "usage": {
+            "input_tokens": 300,
+            "output_tokens": 50,
+        },
+    }
+
+
+@pytest.fixture
+def successful_chat_response() -> dict:
+    """Mock DashScope API response for chat."""
+    return {
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"text": "The invoice total is $150.00 as shown in the bottom-right section."}
+                        ],
+                    }
+                }
+            ]
+        },
+        "usage": {
+            "input_tokens": 800,
+            "output_tokens": 50,
+        },
+    }
+
+
+@pytest.fixture
+def markdown_wrapped_response() -> dict:
+    """Mock response with JSON wrapped in markdown code block."""
+    return {
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": '```json\n{"document_type": "receipt", "confidence": 0.88}\n```'
+                            }
+                        ],
+                    }
+                }
+            ]
+        },
+        "usage": {"input_tokens": 100, "output_tokens": 30},
+    }
+
+
+@pytest.fixture
+def non_json_response() -> dict:
+    """Mock response with plain text (not JSON)."""
+    return {
+        "output": {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"text": "I cannot determine the document type from this image."}
+                        ],
+                    }
+                }
+            ]
+        },
+        "usage": {"input_tokens": 100, "output_tokens": 20},
+    }
+
+
+def _mock_httpx_response(status_code: int, json_data: dict) -> httpx.Response:
+    """Create a mock httpx.Response."""
+    response = httpx.Response(
+        status_code=status_code,
+        json=json_data,
+        request=httpx.Request("POST", BASE_URL),
+    )
+    return response
+
+
+# ---------------------------------------------------------------------------
+# Constructor
+# ---------------------------------------------------------------------------
+
+class TestDashScopeProviderInit:
+    """Tests for DashScopeProvider initialization."""
+
+    def test_creates_with_valid_config(self, mock_settings) -> None:
+        with patch("docmind.library.providers.dashscope.get_settings", return_value=mock_settings):
+            provider = DashScopeProvider()
+            assert provider.provider_name == "DashScope"
+            assert provider.model_name == "qwen-vl-max"
+
+    def test_raises_on_missing_api_key(self) -> None:
+        settings = MagicMock()
+        settings.DASHSCOPE_API_KEY = ""
+        settings.DASHSCOPE_MODEL = "qwen-vl-max"
+        with patch("docmind.library.providers.dashscope.get_settings", return_value=settings):
+            with pytest.raises(RuntimeError, match="DASHSCOPE_API_KEY"):
+                DashScopeProvider()
+
+    def test_uses_default_model(self) -> None:
+        settings = MagicMock()
+        settings.DASHSCOPE_API_KEY = "test-key"
+        settings.DASHSCOPE_MODEL = ""
+        with patch("docmind.library.providers.dashscope.get_settings", return_value=settings):
+            provider = DashScopeProvider()
+            assert provider.model_name == DEFAULT_MODEL
+
+    def test_provider_name_property(self, provider: DashScopeProvider) -> None:
+        assert provider.provider_name == "DashScope"
+
+    def test_model_name_property(self, provider: DashScopeProvider) -> None:
+        assert provider.model_name == "qwen-vl-max"
+
+
+# ---------------------------------------------------------------------------
+# extract
+# ---------------------------------------------------------------------------
+
+class TestDashScopeExtract:
+    """Tests for DashScopeProvider.extract method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_vlm_response(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_extract_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_extract_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        result = await provider.extract(sample_images, "Extract invoice fields")
+
+        assert isinstance(result, dict)
+        assert "content" in result
+        assert "structured_data" in result
+        assert "confidence" in result
+        assert "model" in result
+        assert "usage" in result
+        assert "raw_response" in result
+
+    @pytest.mark.asyncio
+    async def test_structured_data_parsed(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_extract_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_extract_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        result = await provider.extract(sample_images, "Extract invoice fields")
+
+        assert result["structured_data"]["invoice_number"] == "INV-001"
+        assert result["structured_data"]["total"] == 150.00
+        assert result["confidence"] == 0.95
+
+    @pytest.mark.asyncio
+    async def test_sends_images_as_base64(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_extract_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_extract_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        await provider.extract(sample_images, "Extract")
+
+        # Verify the API was called
+        provider._client.post.assert_called_once()
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+
+        # Find user message with image content
+        user_msg = [m for m in messages if m["role"] == "user"][0]
+        image_items = [c for c in user_msg["content"] if "image" in c]
+        assert len(image_items) == 2  # 2 pages
+        for item in image_items:
+            assert item["image"].startswith("data:image/jpeg;base64,")
+
+    @pytest.mark.asyncio
+    async def test_includes_schema_in_prompt(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_extract_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_extract_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        schema = {"type": "object", "properties": {"total": {"type": "number"}}}
+        await provider.extract(sample_images, "Extract", schema=schema)
+
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+        user_msg = [m for m in messages if m["role"] == "user"][0]
+        text_items = [c for c in user_msg["content"] if "text" in c]
+        prompt_text = text_items[0]["text"]
+        assert "Respond with valid JSON matching this schema" in prompt_text
+
+    @pytest.mark.asyncio
+    async def test_includes_system_message(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_extract_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_extract_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        await provider.extract(sample_images, "Extract")
+
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+        system_msgs = [m for m in messages if m["role"] == "system"]
+        assert len(system_msgs) == 1
+
+    @pytest.mark.asyncio
+    async def test_usage_tokens(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_extract_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_extract_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        result = await provider.extract(sample_images, "Extract")
+
+        assert result["usage"]["input_tokens"] == 500
+        assert result["usage"]["output_tokens"] == 100
+
+
+# ---------------------------------------------------------------------------
+# classify
+# ---------------------------------------------------------------------------
+
+class TestDashScopeClassify:
+    """Tests for DashScopeProvider.classify method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_classification(
+        self,
+        provider: DashScopeProvider,
+        sample_image: np.ndarray,
+        successful_classify_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_classify_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        result = await provider.classify(sample_image, ["invoice", "receipt", "contract"])
+
+        assert result["structured_data"]["document_type"] == "invoice"
+        assert result["confidence"] == 0.92
+
+    @pytest.mark.asyncio
+    async def test_sends_single_image(
+        self,
+        provider: DashScopeProvider,
+        sample_image: np.ndarray,
+        successful_classify_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_classify_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        await provider.classify(sample_image, ["invoice", "receipt"])
+
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+        user_msg = [m for m in messages if m["role"] == "user"][0]
+        image_items = [c for c in user_msg["content"] if "image" in c]
+        assert len(image_items) == 1
+
+    @pytest.mark.asyncio
+    async def test_includes_categories_in_prompt(
+        self,
+        provider: DashScopeProvider,
+        sample_image: np.ndarray,
+        successful_classify_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_classify_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        await provider.classify(sample_image, ["invoice", "receipt", "contract"])
+
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+        user_msg = [m for m in messages if m["role"] == "user"][0]
+        text_items = [c for c in user_msg["content"] if "text" in c]
+        prompt_text = text_items[0]["text"]
+        assert "invoice" in prompt_text
+        assert "receipt" in prompt_text
+        assert "contract" in prompt_text
+
+
+# ---------------------------------------------------------------------------
+# chat
+# ---------------------------------------------------------------------------
+
+class TestDashScopeChat:
+    """Tests for DashScopeProvider.chat method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_chat_response(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_chat_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_chat_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        result = await provider.chat(
+            sample_images, "What is the total?", [], "You are a document assistant."
+        )
+
+        assert "content" in result
+        assert "150.00" in result["content"]
+
+    @pytest.mark.asyncio
+    async def test_no_history_includes_images_with_message(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_chat_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_chat_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        await provider.chat(sample_images, "What is this?", [], "System prompt")
+
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+
+        # With no history, images should be in the user message
+        user_msgs = [m for m in messages if m["role"] == "user"]
+        assert len(user_msgs) == 1
+        image_items = [c for c in user_msgs[0]["content"] if "image" in c]
+        assert len(image_items) == 2  # 2 page images
+
+    @pytest.mark.asyncio
+    async def test_with_history_includes_images_in_first_user_msg(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_chat_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_chat_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        history = [
+            {"role": "user", "content": "What document is this?"},
+            {"role": "assistant", "content": "This is an invoice."},
+        ]
+
+        await provider.chat(sample_images, "What is the total?", history, "System prompt")
+
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+
+        # First user message should have images
+        first_user = [m for m in messages if m["role"] == "user"][0]
+        image_items = [c for c in first_user["content"] if "image" in c]
+        assert len(image_items) == 2
+
+    @pytest.mark.asyncio
+    async def test_includes_system_prompt(
+        self,
+        provider: DashScopeProvider,
+        sample_images: list[np.ndarray],
+        successful_chat_response: dict,
+    ) -> None:
+        mock_response = _mock_httpx_response(200, successful_chat_response)
+        provider._client.post = AsyncMock(return_value=mock_response)
+
+        await provider.chat(sample_images, "Hello", [], "Custom system prompt")
+
+        call_kwargs = provider._client.post.call_args
+        payload = call_kwargs.kwargs.get("json") or call_kwargs[1].get("json")
+        messages = payload["input"]["messages"]
+        system_msgs = [m for m in messages if m["role"] == "system"]
+        assert len(system_msgs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+class TestResponseParsing:
+    """Tests for _parse_response method."""
+
+    def test_parses_json_content(
+        self, provider: DashScopeProvider, successful_extract_response: dict
+    ) -> None:
+        result = provider._parse_response(successful_extract_response)
+        assert result["structured_data"]["invoice_number"] == "INV-001"
+        assert result["confidence"] == 0.95
+
+    def test_parses_markdown_wrapped_json(
+        self, provider: DashScopeProvider, markdown_wrapped_response: dict
+    ) -> None:
+        result = provider._parse_response(markdown_wrapped_response)
+        assert result["structured_data"]["document_type"] == "receipt"
+        assert result["confidence"] == 0.88
+
+    def test_fallback_on_non_json(
+        self, provider: DashScopeProvider, non_json_response: dict
+    ) -> None:
+        result = provider._parse_response(non_json_response)
+        assert "raw_text" in result["structured_data"]
+        assert result["confidence"] == 0.5
+
+    def test_includes_model_name(
+        self, provider: DashScopeProvider, successful_extract_response: dict
+    ) -> None:
+        result = provider._parse_response(successful_extract_response)
+        assert result["model"] == "qwen-vl-max"
+
+    def test_includes_usage_tokens(
+        self, provider: DashScopeProvider, successful_extract_response: dict
+    ) -> None:
+        result = provider._parse_response(successful_extract_response)
+        assert result["usage"]["input_tokens"] == 500
+        assert result["usage"]["output_tokens"] == 100
+
+    def test_includes_raw_response(
+        self, provider: DashScopeProvider, successful_extract_response: dict
+    ) -> None:
+        result = provider._parse_response(successful_extract_response)
+        assert result["raw_response"] == successful_extract_response
+
+    def test_handles_empty_choices(self, provider: DashScopeProvider) -> None:
+        raw = {"output": {"choices": []}, "usage": {}}
+        result = provider._parse_response(raw)
+        assert result["content"] == ""
+
+    def test_handles_missing_usage(self, provider: DashScopeProvider) -> None:
+        raw = {
+            "output": {
+                "choices": [{"message": {"content": [{"text": "hello"}]}}]
+            },
+        }
+        result = provider._parse_response(raw)
+        assert result["usage"]["input_tokens"] == 0
+        assert result["usage"]["output_tokens"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Retry and error handling
+# ---------------------------------------------------------------------------
+
+class TestRetryAndErrors:
+    """Tests for _call_api retry logic and error handling."""
+
+    @pytest.mark.asyncio
+    async def test_retries_on_rate_limit(
+        self,
+        provider: DashScopeProvider,
+        successful_extract_response: dict,
+    ) -> None:
+        """Should retry on 429 and succeed on subsequent attempt."""
+        rate_limit_response = _mock_httpx_response(429, {"error": "rate limited"})
+        success_response = _mock_httpx_response(200, successful_extract_response)
+
+        provider._client.post = AsyncMock(
+            side_effect=[rate_limit_response, success_response]
+        )
+
+        messages = [{"role": "user", "content": [{"text": "test"}]}]
+        with patch("docmind.library.providers.dashscope.time.sleep"):
+            result = await provider._call_api(messages)
+
+        assert result["structured_data"]["invoice_number"] == "INV-001"
+        assert provider._client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retries_on_network_error(
+        self,
+        provider: DashScopeProvider,
+        successful_extract_response: dict,
+    ) -> None:
+        """Should retry on transient network errors."""
+        success_response = _mock_httpx_response(200, successful_extract_response)
+
+        provider._client.post = AsyncMock(
+            side_effect=[
+                httpx.ConnectError("Connection refused"),
+                success_response,
+            ]
+        )
+
+        messages = [{"role": "user", "content": [{"text": "test"}]}]
+        with patch("docmind.library.providers.dashscope.time.sleep"):
+            result = await provider._call_api(messages)
+
+        assert provider._client.post.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries(
+        self,
+        provider: DashScopeProvider,
+    ) -> None:
+        """Should raise RuntimeError after all retries exhausted."""
+        provider._client.post = AsyncMock(
+            side_effect=httpx.ConnectError("Connection refused")
+        )
+
+        messages = [{"role": "user", "content": [{"text": "test"}]}]
+        with patch("docmind.library.providers.dashscope.time.sleep"):
+            with pytest.raises(RuntimeError, match=f"failed after {MAX_RETRIES} retries$"):
+                await provider._call_api(messages)
+
+        assert provider._client.post.call_count == MAX_RETRIES
+
+    @pytest.mark.asyncio
+    async def test_raises_immediately_on_non_retryable_error(
+        self,
+        provider: DashScopeProvider,
+    ) -> None:
+        """Non-429 HTTP errors should raise immediately (no retry)."""
+        error_response = _mock_httpx_response(401, {"error": "unauthorized"})
+        provider._client.post = AsyncMock(return_value=error_response)
+
+        messages = [{"role": "user", "content": [{"text": "test"}]}]
+        with pytest.raises(RuntimeError, match="DashScope API error: 401"):
+            await provider._call_api(messages)
+
+        assert provider._client.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_exponential_backoff_delays(
+        self,
+        provider: DashScopeProvider,
+    ) -> None:
+        """Verify exponential backoff timing."""
+        provider._client.post = AsyncMock(
+            side_effect=httpx.ConnectError("timeout")
+        )
+
+        messages = [{"role": "user", "content": [{"text": "test"}]}]
+        with patch("docmind.library.providers.dashscope.time.sleep") as mock_sleep:
+            with pytest.raises(RuntimeError):
+                await provider._call_api(messages)
+
+        sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
+        for i, delay in enumerate(sleep_calls):
+            expected = RETRY_BASE_DELAY * (2 ** i)
+            assert abs(delay - expected) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# health_check
+# ---------------------------------------------------------------------------
+
+class TestHealthCheck:
+    """Tests for DashScopeProvider.health_check method."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_on_200(self, provider: DashScopeProvider) -> None:
+        mock_response = _mock_httpx_response(200, {})
+        provider._client.post = AsyncMock(return_value=mock_response)
+        assert await provider.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_true_on_400(self, provider: DashScopeProvider) -> None:
+        """400 means valid auth but bad request — still healthy."""
+        mock_response = _mock_httpx_response(400, {"error": "bad request"})
+        provider._client.post = AsyncMock(return_value=mock_response)
+        assert await provider.health_check() is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_401(self, provider: DashScopeProvider) -> None:
+        mock_response = _mock_httpx_response(401, {"error": "unauthorized"})
+        provider._client.post = AsyncMock(return_value=mock_response)
+        assert await provider.health_check() is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_exception(self, provider: DashScopeProvider) -> None:
+        provider._client.post = AsyncMock(side_effect=httpx.ConnectError("timeout"))
+        assert await provider.health_check() is False


### PR DESCRIPTION
## Summary
- Implement `extract()`, `classify()`, `chat()` methods on `DashScopeProvider` replacing `NotImplementedError` stubs
- Add `_call_api()` with retry + exponential backoff on 429/network errors, immediate raise on other HTTP errors
- Add `_parse_response()` handling JSON, markdown-wrapped JSON, and plain text fallback
- Add `_build_headers()` and `_build_payload()` helpers
- Confidence scores clamped to [0.0, 1.0], sanitized error messages (no API key leakage)
- 35 unit tests — all mocked, no real API calls

## Test plan
- [x] `pytest backend/tests/unit/library/providers/test_dashscope.py -v` — 35/35 pass
- [x] `pytest backend/tests/unit/ -v` — 208/208 pass
- [x] Code review findings addressed (sanitized RuntimeError, confidence clamping, empty-choices warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)