### PR TITLE
feat(pipeline): postprocess_node + store_node #14

### DIFF
--- a/backend/src/docmind/library/pipeline/processing.py
+++ b/backend/src/docmind/library/pipeline/processing.py
@@ -11,6 +11,7 @@ import asyncio
 import dataclasses
 import logging
 import time
+import uuid
 from datetime import datetime, timezone
 from typing import Any, Callable, TypedDict
 
@@ -385,6 +386,361 @@ def extract_node(state: dict) -> dict:
         return {
             "status": "error",
             "error_message": "Extraction failed. See server logs for details.",
+        }
+
+
+CONFIDENCE_VLM_WEIGHT = 0.7
+CONFIDENCE_CV_WEIGHT = 0.3
+LOW_CONFIDENCE_THRESHOLD = 0.5
+
+
+def _lookup_cv_quality(
+    bounding_box: dict,
+    quality_map: dict,
+    page_height: int = 4,
+    page_width: int = 4,
+) -> float:
+    """Map bounding box center to nearest grid cell in quality map.
+
+    Args:
+        bounding_box: Dict with x, y, width, height as ratios (0.0-1.0).
+        quality_map: Dict mapping "row,col" strings to quality dicts.
+        page_height: Number of grid rows.
+        page_width: Number of grid columns.
+
+    Returns:
+        Overall quality score for the grid cell, or 0.5 as fallback.
+    """
+    if not quality_map or not bounding_box:
+        return 0.5
+    center_y = bounding_box.get("y", 0.5) + bounding_box.get("height", 0) / 2
+    center_x = bounding_box.get("x", 0.5) + bounding_box.get("width", 0) / 2
+    grid_row = min(int(center_y * page_height), page_height - 1)
+    grid_col = min(int(center_x * page_width), page_width - 1)
+    key = f"{grid_row},{grid_col}"
+    region = quality_map.get(key)
+    if region is None:
+        return 0.5
+    return region.get("overall_score", 0.5)
+
+
+def _merge_confidence(vlm_confidence: float, cv_quality: float) -> float:
+    """Merge VLM confidence with CV quality score.
+
+    Formula: final = vlm * 0.7 + cv * 0.3, clamped to [0.0, 1.0].
+
+    Args:
+        vlm_confidence: VLM extraction confidence (0.0-1.0).
+        cv_quality: CV region quality score (0.0-1.0).
+
+    Returns:
+        Merged confidence rounded to 4 decimal places.
+    """
+    merged = (vlm_confidence * CONFIDENCE_VLM_WEIGHT) + (cv_quality * CONFIDENCE_CV_WEIGHT)
+    return round(max(0.0, min(1.0, merged)), 4)
+
+
+def _generate_low_confidence_explanation(
+    field: dict, cv_quality: float
+) -> str | None:
+    """Generate human-readable explanation for low-confidence fields.
+
+    Args:
+        field: Enhanced field dict with confidence, vlm_confidence, is_missing.
+        cv_quality: CV quality score for this field's region.
+
+    Returns:
+        Explanation string if confidence < threshold, None otherwise.
+    """
+    confidence = field.get("confidence", 0.0)
+    if confidence >= LOW_CONFIDENCE_THRESHOLD:
+        return None
+    reasons = []
+    vlm_conf = field.get("vlm_confidence", 0.0)
+    if vlm_conf < 0.5:
+        reasons.append("VLM had low confidence in reading this field")
+    if cv_quality < 0.4:
+        reasons.append(
+            "image quality in this region is poor (possible blur or noise)"
+        )
+    if field.get("is_missing"):
+        reasons.append("field was expected but not found in the document")
+    if not reasons:
+        reasons.append(
+            "combined confidence from VLM and image quality is below threshold"
+        )
+    return "; ".join(reasons)
+
+
+def _validate_template_fields(
+    fields: list[dict], template_type: str | None
+) -> list[dict]:
+    """Validate extracted fields against template requirements.
+
+    Adds missing required fields as placeholder entries with
+    confidence=0.0, is_missing=True, is_required=True.
+
+    Args:
+        fields: List of enhanced field dicts.
+        template_type: Template name, or None for general mode.
+
+    Returns:
+        Validated list of field dicts (new list, no mutation).
+    """
+    if not template_type:
+        return list(fields)
+
+    required_map = {
+        "invoice": ["invoice_number", "date", "total_amount", "vendor_name"],
+        "receipt": ["date", "total_amount", "merchant_name"],
+        "medical_report": ["patient_name", "report_date", "report_type"],
+        "contract": ["parties", "effective_date", "contract_type"],
+        "id_document": ["full_name", "document_number", "date_of_birth"],
+    }
+    required_fields = required_map.get(template_type, [])
+    found_keys = {f.get("field_key") for f in fields if f.get("field_key")}
+
+    validated_fields = []
+    for field in fields:
+        updated = {**field}
+        if updated.get("field_key") in required_fields:
+            updated["is_required"] = True
+        validated_fields.append(updated)
+
+    for req_key in required_fields:
+        if req_key not in found_keys:
+
+
+            validated_fields.append({
+                "id": str(uuid.uuid4()),
+                "field_type": "key_value",
+                "field_key": req_key,
+                "field_value": "",
+                "page_number": 1,
+                "bounding_box": {},
+                "confidence": 0.0,
+                "vlm_confidence": 0.0,
+                "cv_quality_score": 0.0,
+                "is_required": True,
+                "is_missing": True,
+            })
+    return validated_fields
+
+
+def postprocess_node(state: dict) -> dict:
+    """Postprocess extraction results: merge confidence, validate, explain.
+
+    Steps:
+    1. Merge VLM confidence with CV quality score per field
+    2. Validate against template (if template mode)
+    3. Generate explanations for low-confidence fields
+    4. Build comparison data (enhanced vs raw)
+    5. Record audit entry
+
+    Args:
+        state: ProcessingState dict with raw_fields, quality_map, template_type.
+
+    Returns:
+        State update dict with enhanced_fields, comparison_data, audit_entries.
+        On error, returns status='error' with error_message.
+    """
+    start_time = time.time()
+    progress_callback = state.get("progress_callback")
+
+    def _notify(progress: float, message: str) -> None:
+        if progress_callback is not None:
+            progress_callback("postprocess", progress, message)
+
+    try:
+        raw_fields = state.get("raw_fields", [])
+        quality_map = state.get("quality_map", {})
+        template_type = state.get("template_type")
+
+        _notify(0.65, "Merging confidence scores")
+
+
+
+        enhanced_fields = []
+        corrected_ids = []
+
+        for field in raw_fields:
+            field_id = field.get("id", str(uuid.uuid4()))
+            bbox = field.get("bounding_box", {})
+            cv_quality = _lookup_cv_quality(bbox, quality_map)
+            vlm_conf = field.get(
+                "vlm_confidence", field.get("confidence", 0.5)
+            )
+            merged_conf = _merge_confidence(vlm_conf, cv_quality)
+
+            enhanced = {
+                **field,
+                "id": field_id,
+                "confidence": merged_conf,
+                "vlm_confidence": vlm_conf,
+                "cv_quality_score": cv_quality,
+                "is_required": field.get("is_required", False),
+                "is_missing": field.get("is_missing", False),
+            }
+
+            original_conf = field.get("confidence", 0.0)
+            if abs(merged_conf - original_conf) > 0.05:
+                corrected_ids.append(field_id)
+
+            enhanced_fields.append(enhanced)
+
+        _notify(0.75, "Validating template fields")
+
+        enhanced_fields = _validate_template_fields(enhanced_fields, template_type)
+
+        # Track added fields (from template validation)
+        added_ids = []
+        raw_field_ids = {f.get("id") for f in raw_fields}
+        for field in enhanced_fields:
+            if field.get("is_missing") and field.get("id") not in raw_field_ids:
+                added_ids.append(field["id"])
+
+        _notify(0.80, "Generating explanations")
+
+        # Generate explanations for low-confidence fields (immutable)
+        final_fields = []
+        for field in enhanced_fields:
+            bbox = field.get("bounding_box", {})
+            cv_quality = _lookup_cv_quality(bbox, quality_map)
+            explanation = _generate_low_confidence_explanation(field, cv_quality)
+            if explanation:
+                field = {**field, "low_confidence_reason": explanation}
+            final_fields.append(field)
+
+        comparison_data = {
+            "corrected": corrected_ids,
+            "added": added_ids,
+        }
+
+        duration_ms = int((time.time() - start_time) * 1000)
+
+        audit_entry: AuditEntry = {
+            "step_name": "postprocess",
+            "step_order": 3,
+            "input_summary": {
+                "raw_field_count": len(raw_fields),
+                "quality_regions": len(quality_map),
+            },
+            "output_summary": {
+                "enhanced_field_count": len(final_fields),
+                "corrected_count": len(corrected_ids),
+                "added_count": len(added_ids),
+                "low_confidence_count": sum(
+                    1 for f in final_fields
+                    if f.get("confidence", 1.0) < LOW_CONFIDENCE_THRESHOLD
+                ),
+            },
+            "parameters": {
+                "vlm_weight": CONFIDENCE_VLM_WEIGHT,
+                "cv_weight": CONFIDENCE_CV_WEIGHT,
+                "low_confidence_threshold": LOW_CONFIDENCE_THRESHOLD,
+            },
+            "duration_ms": duration_ms,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        existing_entries = list(state.get("audit_entries", []))
+        existing_entries.append(audit_entry)
+
+        _notify(1.0, "Postprocessing complete")
+
+        return {
+            "enhanced_fields": final_fields,
+            "comparison_data": comparison_data,
+            "audit_entries": existing_entries,
+        }
+
+    except Exception as e:
+        logger.error("Postprocessing failed: %s", e, exc_info=True)
+        return {
+            "status": "error",
+            "error_message": "Postprocessing failed. See server logs for details.",
+        }
+
+
+async def _persist_results(state: dict, extraction_id: str) -> None:
+    """Persist extraction results to the database.
+
+    Stub — will be implemented when DB layer is wired up.
+    Currently a no-op placeholder that tests can mock.
+
+    Args:
+        state: ProcessingState dict with enhanced_fields, audit_entries, etc.
+        extraction_id: UUID string for the new extraction record.
+    """
+    logger.info(
+        "Persisting extraction %s for document %s (stub)",
+        extraction_id,
+        state.get("document_id"),
+    )
+
+
+def store_node(state: dict) -> dict:
+    """Store extraction results to the database.
+
+    Generates a new extraction_id, persists results via _persist_results,
+    and sets pipeline status to 'ready'.
+
+    Args:
+        state: ProcessingState dict with enhanced_fields, audit_entries, etc.
+
+    Returns:
+        State update dict with extraction_id, status, audit_entries.
+        On error, returns status='error' with error_message.
+    """
+    start_time = time.time()
+    progress_callback = state.get("progress_callback")
+
+    def _notify(progress: float, message: str) -> None:
+        if progress_callback is not None:
+            progress_callback("store", progress, message)
+
+    try:
+
+
+        extraction_id = str(uuid.uuid4())
+
+        _notify(0.9, "Persisting extraction results")
+
+        asyncio.run(_persist_results(state, extraction_id))
+
+        duration_ms = int((time.time() - start_time) * 1000)
+
+        audit_entry: AuditEntry = {
+            "step_name": "store",
+            "step_order": 4,
+            "input_summary": {
+                "document_id": state.get("document_id", ""),
+                "field_count": len(state.get("enhanced_fields", [])),
+            },
+            "output_summary": {
+                "extraction_id": extraction_id,
+            },
+            "parameters": {},
+            "duration_ms": duration_ms,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+
+        existing_entries = list(state.get("audit_entries", []))
+        existing_entries.append(audit_entry)
+
+        _notify(1.0, "Storage complete")
+
+        return {
+            "extraction_id": extraction_id,
+            "status": "ready",
+            "audit_entries": existing_entries,
+        }
+
+    except Exception as e:
+        logger.error("Storage failed: %s", e, exc_info=True)
+        return {
+            "status": "error",
+            "error_message": "Storage failed. See server logs for details.",
         }
 
 

--- a/backend/tests/unit/library/pipeline/test_postprocess_node.py
+++ b/backend/tests/unit/library/pipeline/test_postprocess_node.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for postprocess_node and its helper functions.
+
+Tests verify confidence merging formula, CV quality lookup,
+template validation, low-confidence explanations, and audit entries.
+No database interaction — all pure functions.
+"""
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_raw_field(
+    field_key: str = "amount",
+    confidence: float = 0.9,
+    vlm_confidence: float | None = None,
+    bounding_box: dict | None = None,
+    is_required: bool = False,
+    is_missing: bool = False,
+    field_id: str | None = None,
+) -> dict:
+    """Create a raw extracted field dict."""
+    return {
+        "id": field_id or str(uuid.uuid4()),
+        "field_type": "key_value",
+        "field_key": field_key,
+        "field_value": "100.00",
+        "page_number": 1,
+        "bounding_box": bounding_box or {"x": 0.5, "y": 0.5, "width": 0.2, "height": 0.05},
+        "confidence": confidence,
+        "vlm_confidence": vlm_confidence if vlm_confidence is not None else confidence,
+        "is_required": is_required,
+        "is_missing": is_missing,
+    }
+
+
+def _make_state(
+    raw_fields: list[dict] | None = None,
+    quality_map: dict | None = None,
+    template_type: str | None = None,
+    callback: object | None = None,
+) -> dict:
+    """Build a ProcessingState for postprocess_node."""
+    return {
+        "document_id": "doc-123",
+        "user_id": "user-456",
+        "file_bytes": b"",
+        "file_type": "pdf",
+        "template_type": template_type,
+        "page_images": [],
+        "page_count": 1,
+        "quality_map": quality_map or {},
+        "skew_angles": [],
+        "raw_fields": raw_fields or [_make_raw_field()],
+        "vlm_response": {},
+        "document_type": "invoice",
+        "enhanced_fields": [],
+        "comparison_data": {},
+        "extraction_id": "",
+        "status": "processing",
+        "error_message": None,
+        "audit_entries": [],
+        "progress_callback": callback,
+    }
+
+
+class TestMergeConfidence:
+    """Tests for _merge_confidence helper."""
+
+    def test_standard_merge(self):
+        from docmind.library.pipeline.processing import _merge_confidence
+
+        result = _merge_confidence(vlm_confidence=0.9, cv_quality=0.8)
+        expected = 0.9 * 0.7 + 0.8 * 0.3  # 0.63 + 0.24 = 0.87
+        assert abs(result - expected) < 0.001
+
+    def test_clamped_to_max_1(self):
+        from docmind.library.pipeline.processing import _merge_confidence
+
+        result = _merge_confidence(vlm_confidence=1.0, cv_quality=1.0)
+        assert result <= 1.0
+
+    def test_clamped_to_min_0(self):
+        from docmind.library.pipeline.processing import _merge_confidence
+
+        result = _merge_confidence(vlm_confidence=0.0, cv_quality=0.0)
+        assert result >= 0.0
+
+    def test_rounded_to_4_decimals(self):
+        from docmind.library.pipeline.processing import _merge_confidence
+
+        result = _merge_confidence(vlm_confidence=0.333, cv_quality=0.777)
+        assert len(str(result).split(".")[-1]) <= 4
+
+    def test_vlm_weighted_more_than_cv(self):
+        """VLM confidence has 70% weight vs CV 30%."""
+        from docmind.library.pipeline.processing import _merge_confidence
+
+        high_vlm = _merge_confidence(vlm_confidence=1.0, cv_quality=0.0)
+        high_cv = _merge_confidence(vlm_confidence=0.0, cv_quality=1.0)
+        assert high_vlm > high_cv
+
+
+class TestLookupCvQuality:
+    """Tests for _lookup_cv_quality helper."""
+
+    def test_maps_bbox_center_to_grid_cell(self):
+        from docmind.library.pipeline.processing import _lookup_cv_quality
+
+        quality_map = {"1,2": {"overall_score": 0.85}}
+        bbox = {"x": 0.5, "y": 0.3, "width": 0.1, "height": 0.1}
+        # center_x = 0.55, center_y = 0.35
+        # grid_col = int(0.55 * 4) = 2, grid_row = int(0.35 * 4) = 1
+        result = _lookup_cv_quality(bbox, quality_map)
+        assert result == 0.85
+
+    def test_returns_fallback_when_no_quality_map(self):
+        from docmind.library.pipeline.processing import _lookup_cv_quality
+
+        result = _lookup_cv_quality({"x": 0.5, "y": 0.5}, {})
+        assert result == 0.5
+
+    def test_returns_fallback_when_no_bbox(self):
+        from docmind.library.pipeline.processing import _lookup_cv_quality
+
+        result = _lookup_cv_quality({}, {"0,0": {"overall_score": 0.9}})
+        assert result == 0.5
+
+    def test_returns_fallback_when_cell_not_found(self):
+        from docmind.library.pipeline.processing import _lookup_cv_quality
+
+        quality_map = {"0,0": {"overall_score": 0.9}}
+        bbox = {"x": 0.9, "y": 0.9, "width": 0.05, "height": 0.05}
+        result = _lookup_cv_quality(bbox, quality_map)
+        # Cell (3,3) not in map -> fallback
+        assert result == 0.5
+
+
+class TestGenerateLowConfidenceExplanation:
+    """Tests for _generate_low_confidence_explanation."""
+
+    def test_returns_none_for_high_confidence(self):
+        from docmind.library.pipeline.processing import _generate_low_confidence_explanation
+
+        field = {"confidence": 0.8, "vlm_confidence": 0.8}
+        result = _generate_low_confidence_explanation(field, cv_quality=0.9)
+        assert result is None
+
+    def test_returns_explanation_for_low_vlm_confidence(self):
+        from docmind.library.pipeline.processing import _generate_low_confidence_explanation
+
+        field = {"confidence": 0.3, "vlm_confidence": 0.3}
+        result = _generate_low_confidence_explanation(field, cv_quality=0.8)
+        assert result is not None
+        assert "VLM" in result
+
+    def test_returns_explanation_for_poor_image_quality(self):
+        from docmind.library.pipeline.processing import _generate_low_confidence_explanation
+
+        field = {"confidence": 0.4, "vlm_confidence": 0.6}
+        result = _generate_low_confidence_explanation(field, cv_quality=0.2)
+        assert result is not None
+        assert "quality" in result.lower() or "blur" in result.lower() or "noise" in result.lower()
+
+    def test_returns_explanation_for_missing_field(self):
+        from docmind.library.pipeline.processing import _generate_low_confidence_explanation
+
+        field = {"confidence": 0.0, "vlm_confidence": 0.0, "is_missing": True}
+        result = _generate_low_confidence_explanation(field, cv_quality=0.5)
+        assert result is not None
+        assert "not found" in result or "missing" in result
+
+    def test_returns_generic_explanation_when_no_specific_reason(self):
+        from docmind.library.pipeline.processing import _generate_low_confidence_explanation
+
+        field = {"confidence": 0.4, "vlm_confidence": 0.6}
+        result = _generate_low_confidence_explanation(field, cv_quality=0.8)
+        assert result is not None
+        assert "threshold" in result or "below" in result
+
+
+class TestValidateTemplateFields:
+    """Tests for _validate_template_fields."""
+
+    def test_adds_missing_required_fields_as_placeholders(self):
+        from docmind.library.pipeline.processing import _validate_template_fields
+
+        fields = [_make_raw_field(field_key="invoice_number")]
+        result = _validate_template_fields(fields, "invoice")
+
+        keys = [f["field_key"] for f in result]
+        assert "date" in keys
+        assert "total_amount" in keys
+        assert "vendor_name" in keys
+
+    def test_placeholder_fields_have_correct_markers(self):
+        from docmind.library.pipeline.processing import _validate_template_fields
+
+        fields = []
+        result = _validate_template_fields(fields, "invoice")
+
+        for field in result:
+            assert field["is_required"] is True
+            assert field["is_missing"] is True
+            assert field["confidence"] == 0.0
+            assert field["field_value"] == ""
+
+    def test_marks_existing_required_fields(self):
+        from docmind.library.pipeline.processing import _validate_template_fields
+
+        fields = [_make_raw_field(field_key="invoice_number", confidence=0.9)]
+        result = _validate_template_fields(fields, "invoice")
+
+        inv_field = next(f for f in result if f["field_key"] == "invoice_number")
+        assert inv_field["is_required"] is True
+        assert inv_field.get("is_missing", False) is False
+
+    def test_returns_fields_unchanged_when_no_template(self):
+        from docmind.library.pipeline.processing import _validate_template_fields
+
+        fields = [_make_raw_field(field_key="random_field")]
+        result = _validate_template_fields(fields, None)
+
+        assert len(result) == 1
+        assert result[0]["field_key"] == "random_field"
+
+    def test_does_not_duplicate_existing_required_fields(self):
+        from docmind.library.pipeline.processing import _validate_template_fields
+
+        fields = [
+            _make_raw_field(field_key="invoice_number"),
+            _make_raw_field(field_key="date"),
+            _make_raw_field(field_key="total_amount"),
+            _make_raw_field(field_key="vendor_name"),
+        ]
+        result = _validate_template_fields(fields, "invoice")
+
+        keys = [f["field_key"] for f in result]
+        assert keys.count("invoice_number") == 1
+        assert keys.count("date") == 1
+
+
+class TestPostprocessNode:
+    """Integration tests for postprocess_node."""
+
+    def test_merges_confidence_on_all_fields(self):
+        from docmind.library.pipeline.processing import postprocess_node
+
+        quality_map = {"2,2": {"overall_score": 0.8}}
+        fields = [_make_raw_field(
+            vlm_confidence=0.9,
+            bounding_box={"x": 0.5, "y": 0.5, "width": 0.1, "height": 0.1},
+        )]
+        state = _make_state(raw_fields=fields, quality_map=quality_map)
+        result = postprocess_node(state)
+
+        enhanced = result["enhanced_fields"]
+        assert len(enhanced) == 1
+        assert "confidence" in enhanced[0]
+        assert "vlm_confidence" in enhanced[0]
+        assert "cv_quality_score" in enhanced[0]
+
+    def test_creates_comparison_data(self):
+        from docmind.library.pipeline.processing import postprocess_node
+
+        state = _make_state()
+        result = postprocess_node(state)
+
+        assert "comparison_data" in result
+        assert "corrected" in result["comparison_data"]
+        assert "added" in result["comparison_data"]
+
+    def test_creates_audit_entry(self):
+        from docmind.library.pipeline.processing import postprocess_node
+
+        state = _make_state()
+        result = postprocess_node(state)
+
+        assert len(result["audit_entries"]) >= 1
+        entry = result["audit_entries"][-1]
+        assert entry["step_name"] == "postprocess"
+        assert entry["step_order"] == 3
+
+    def test_returns_error_on_exception(self):
+        from docmind.library.pipeline.processing import postprocess_node
+
+        state = _make_state()
+        state["raw_fields"] = "not-a-list"  # type: ignore
+        result = postprocess_node(state)
+
+        assert result["status"] == "error"
+        assert "Postprocessing failed" in result["error_message"]
+
+    def test_callback_invoked(self):
+        from docmind.library.pipeline.processing import postprocess_node
+
+        callback = MagicMock()
+        state = _make_state(callback=callback)
+        postprocess_node(state)
+
+        assert callback.call_count >= 2

--- a/backend/tests/unit/library/pipeline/test_store_node.py
+++ b/backend/tests/unit/library/pipeline/test_store_node.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for store_node pipeline function.
+
+Database operations are mocked. Tests verify that store_node
+creates the correct ORM objects, calls commit, updates document
+status, and handles errors properly.
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _make_state(
+    enhanced_fields: list[dict] | None = None,
+    audit_entries: list[dict] | None = None,
+    callback: object | None = None,
+) -> dict:
+    """Build a ProcessingState for store_node."""
+    if enhanced_fields is None:
+        enhanced_fields = [
+            {
+                "id": str(uuid.uuid4()),
+                "field_type": "key_value",
+                "field_key": "total",
+                "field_value": "$500",
+                "page_number": 1,
+                "bounding_box": {"x": 0.5, "y": 0.8, "width": 0.2, "height": 0.05},
+                "confidence": 0.85,
+                "vlm_confidence": 0.9,
+                "cv_quality_score": 0.7,
+                "is_required": False,
+                "is_missing": False,
+            },
+        ]
+    if audit_entries is None:
+        audit_entries = [
+            {
+                "step_name": "preprocess",
+                "step_order": 1,
+                "input_summary": {},
+                "output_summary": {},
+                "parameters": {},
+                "duration_ms": 100,
+            },
+        ]
+    return {
+        "document_id": "doc-123",
+        "user_id": "user-456",
+        "file_bytes": b"",
+        "file_type": "pdf",
+        "template_type": None,
+        "page_images": [],
+        "page_count": 2,
+        "quality_map": {},
+        "skew_angles": [],
+        "raw_fields": [],
+        "vlm_response": {},
+        "document_type": "invoice",
+        "enhanced_fields": enhanced_fields,
+        "comparison_data": {"corrected": [], "added": []},
+        "extraction_id": "",
+        "status": "processing",
+        "error_message": None,
+        "audit_entries": audit_entries,
+        "progress_callback": callback,
+    }
+
+
+class TestStoreNode:
+    """Tests for store_node database persistence."""
+
+    @patch("docmind.library.pipeline.processing._persist_results", new_callable=AsyncMock)
+    def test_returns_extraction_id(self, mock_persist):
+        """store_node generates and returns a UUID extraction_id."""
+        from docmind.library.pipeline.processing import store_node
+
+        state = _make_state()
+        result = store_node(state)
+
+        assert "extraction_id" in result
+        uuid.UUID(result["extraction_id"])
+
+    @patch("docmind.library.pipeline.processing._persist_results", new_callable=AsyncMock)
+    def test_sets_status_to_ready(self, mock_persist):
+        """store_node sets status to 'ready' on success."""
+        from docmind.library.pipeline.processing import store_node
+
+        state = _make_state()
+        result = store_node(state)
+
+        assert result["status"] == "ready"
+
+    @patch("docmind.library.pipeline.processing._persist_results", new_callable=AsyncMock)
+    def test_calls_persist_with_state_and_extraction_id(self, mock_persist):
+        """store_node calls _persist_results with the state and extraction_id."""
+        from docmind.library.pipeline.processing import store_node
+
+        state = _make_state()
+        result = store_node(state)
+
+        mock_persist.assert_called_once()
+        call_args = mock_persist.call_args
+        assert call_args[0][0] is state or call_args[1].get("state") is state
+
+    @patch("docmind.library.pipeline.processing._persist_results", new_callable=AsyncMock)
+    def test_creates_store_audit_entry(self, mock_persist):
+        """store_node appends its own audit entry with step_name='store'."""
+        from docmind.library.pipeline.processing import store_node
+
+        state = _make_state()
+        result = store_node(state)
+
+        store_entry = result["audit_entries"][-1]
+        assert store_entry["step_name"] == "store"
+        assert store_entry["step_order"] == 4
+        assert "extraction_id" in store_entry["output_summary"]
+
+    @patch("docmind.library.pipeline.processing._persist_results", new_callable=AsyncMock)
+    def test_preserves_existing_audit_entries(self, mock_persist):
+        """Existing audit entries are preserved and store entry appended."""
+        from docmind.library.pipeline.processing import store_node
+
+        existing = [{"step_name": "preprocess", "step_order": 1}]
+        state = _make_state(audit_entries=existing)
+        result = store_node(state)
+
+        assert len(result["audit_entries"]) == 2
+        assert result["audit_entries"][0]["step_name"] == "preprocess"
+        assert result["audit_entries"][-1]["step_name"] == "store"
+
+    @patch("docmind.library.pipeline.processing._persist_results", new_callable=AsyncMock)
+    def test_returns_error_on_db_failure(self, mock_persist):
+        """If _persist_results raises, returns status='error'."""
+        from docmind.library.pipeline.processing import store_node
+
+        mock_persist.side_effect = RuntimeError("Connection refused")
+
+        state = _make_state()
+        result = store_node(state)
+
+        assert result["status"] == "error"
+        assert "Storage failed" in result["error_message"]
+
+    @patch("docmind.library.pipeline.processing._persist_results", new_callable=AsyncMock)
+    def test_callback_invoked(self, mock_persist):
+        """progress_callback is called during store."""
+        from docmind.library.pipeline.processing import store_node
+
+        callback = MagicMock()
+        state = _make_state(callback=callback)
+        store_node(state)
+
+        assert callback.call_count >= 1


### PR DESCRIPTION
## Summary

- Add `postprocess_node`: merges VLM confidence (70%) with CV quality (30%), validates template fields, generates low-confidence explanations, builds comparison data
- Add `store_node`: generates extraction_id (UUID4), calls `_persist_results` stub via `asyncio.run()`, sets status to "ready"
- Add helper functions: `_merge_confidence`, `_lookup_cv_quality`, `_generate_low_confidence_explanation`, `_validate_template_fields`
- Add constants: `CONFIDENCE_VLM_WEIGHT`, `CONFIDENCE_CV_WEIGHT`, `LOW_CONFIDENCE_THRESHOLD`

## Test plan

- [x] 24 postprocess tests (merge confidence, CV quality lookup, low-confidence explanations, template validation, node integration)
- [x] 7 store tests (extraction_id, status, persist call, audit entries, error handling, callback)
- [x] All 302 unit tests pass
- [x] All existing pipeline tests (preprocess, extract general, extract template) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)