### PR TITLE
feat(pipeline): wire processing graph + SSE endpoint #15

### DIFF
--- a/backend/src/docmind/library/pipeline/processing.py
+++ b/backend/src/docmind/library/pipeline/processing.py
@@ -744,9 +744,58 @@ def store_node(state: dict) -> dict:
         }
 
 
+def should_continue(state: dict) -> str:
+    """Conditional edge function for the processing graph.
+
+    Returns "end" if the pipeline has errored, "continue" otherwise.
+    """
+    if state.get("status") == "error":
+        return "end"
+    return "continue"
+
+
+def build_processing_graph():
+    """Build and compile the LangGraph processing pipeline.
+
+    Graph: preprocess -> extract -> postprocess -> store
+    Each node has a conditional edge that short-circuits to END on error.
+
+    Returns:
+        Compiled StateGraph ready for invocation.
+    """
+    from langgraph.graph import END, StateGraph
+
+    graph = StateGraph(ProcessingState)
+    graph.add_node("preprocess", preprocess_node)
+    graph.add_node("extract", extract_node)
+    graph.add_node("postprocess", postprocess_node)
+    graph.add_node("store", store_node)
+    graph.set_entry_point("preprocess")
+    graph.add_conditional_edges(
+        "preprocess", should_continue, {"continue": "extract", "end": END}
+    )
+    graph.add_conditional_edges(
+        "extract", should_continue, {"continue": "postprocess", "end": END}
+    )
+    graph.add_conditional_edges(
+        "postprocess", should_continue, {"continue": "store", "end": END}
+    )
+    graph.add_edge("store", END)
+    return graph.compile()
+
+
+processing_graph = build_processing_graph()
+
+
 def run_processing_pipeline(initial_state: dict) -> dict:
     """Run the full processing pipeline.
 
-    Stub implementation — raises NotImplementedError.
+    Invokes the compiled LangGraph with the given initial state.
+
+    Args:
+        initial_state: ProcessingState dict with document data.
+
+    Returns:
+        Final state dict after all nodes have executed.
     """
-    raise NotImplementedError("Processing pipeline not yet implemented")
+    return processing_graph.invoke(initial_state)

--- a/backend/src/docmind/modules/documents/usecase.py
+++ b/backend/src/docmind/modules/documents/usecase.py
@@ -10,12 +10,15 @@ from datetime import datetime, timezone
 from typing import AsyncGenerator
 
 from docmind.core.logging import get_logger
+from docmind.library.pipeline.processing import run_processing_pipeline
 
 from .repositories import DocumentRepository
 from .schemas import DocumentListResponse, DocumentResponse
 from .services import DocumentService
 
 logger = get_logger(__name__)
+
+_HEARTBEAT_TIMEOUT = 30.0
 
 
 class DocumentUseCase:
@@ -113,9 +116,88 @@ class DocumentUseCase:
     ) -> AsyncGenerator[str, None]:
         import json
 
-        payload = {
-            "step": "complete",
-            "progress": 100,
-            "message": "Stub - not implemented",
+        def _sse(step: str, progress: int, message: str) -> str:
+            return f"data: {json.dumps({'step': step, 'progress': progress, 'message': message})}\n\n"
+
+        # Look up document
+        doc = await self.repo.get_by_id(document_id, user_id="")
+        if doc is None:
+            yield _sse("error", 0, "Document not found")
+            return
+
+        # Update status to processing
+        await self.repo.update_status(document_id, "processing")
+
+        # Load file bytes
+        try:
+            file_bytes = await asyncio.to_thread(
+                self.service.load_file_bytes, doc.storage_path
+            )
+        except Exception as e:
+            logger.error("file_load_failed: %s", e)
+            await self.repo.update_status(document_id, "error")
+            yield _sse("error", 0, "Failed to load document file")
+            return
+
+        # Build initial pipeline state
+        queue: asyncio.Queue[dict | None] = asyncio.Queue()
+
+        def on_progress(step: str, progress: float, message: str) -> None:
+            queue.put_nowait({"step": step, "progress": int(progress), "message": message})
+
+        initial_state: dict = {
+            "document_id": document_id,
+            "user_id": "",
+            "file_bytes": file_bytes,
+            "file_type": getattr(doc, "file_type", "pdf"),
+            "template_type": template_type,
+            "page_images": [],
+            "page_count": 0,
+            "quality_map": {},
+            "skew_angles": [],
+            "raw_fields": [],
+            "vlm_response": {},
+            "document_type": None,
+            "enhanced_fields": [],
+            "comparison_data": {},
+            "extraction_id": "",
+            "status": "processing",
+            "error_message": None,
+            "audit_entries": [],
+            "progress_callback": on_progress,
         }
-        yield f"data: {json.dumps(payload)}\n\n"
+
+        # Run pipeline in background thread
+        pipeline_task = asyncio.create_task(
+            asyncio.to_thread(run_processing_pipeline, initial_state)
+        )
+
+        # Yield SSE events from the queue
+        try:
+            while not pipeline_task.done():
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_TIMEOUT)
+                    if event is None:
+                        break
+                    yield _sse(event["step"], event["progress"], event["message"])
+                except asyncio.TimeoutError:
+                    yield _sse("heartbeat", -1, "alive")
+
+            # Drain remaining events
+            while not queue.empty():
+                event = queue.get_nowait()
+                if event is not None:
+                    yield _sse(event["step"], event["progress"], event["message"])
+
+            # Check pipeline result
+            result = await pipeline_task
+            if result.get("status") == "error":
+                await self.repo.update_status(document_id, "error")
+                yield _sse("error", 0, result.get("error_message", "Processing failed"))
+            else:
+                yield _sse("complete", 100, "Done")
+
+        except Exception as e:
+            logger.error("processing_stream_error: %s", e, exc_info=True)
+            await self.repo.update_status(document_id, "error")
+            yield _sse("error", 0, "Processing failed unexpectedly")

--- a/backend/tests/unit/library/pipeline/test_pipeline_graph.py
+++ b/backend/tests/unit/library/pipeline/test_pipeline_graph.py
@@ -1,0 +1,79 @@
+"""
+Unit tests for the processing pipeline graph wiring:
+should_continue, build_processing_graph, run_processing_pipeline.
+
+Individual nodes are mocked — these tests verify graph structure
+and flow control (normal flow + error short-circuit).
+"""
+from unittest.mock import patch
+
+
+class TestShouldContinue:
+    """Tests for the should_continue conditional edge function."""
+
+    def test_returns_continue_when_no_error(self):
+        from docmind.library.pipeline.processing import should_continue
+
+        state = {"status": "processing"}
+        assert should_continue(state) == "continue"
+
+    def test_returns_end_when_error(self):
+        from docmind.library.pipeline.processing import should_continue
+
+        state = {"status": "error"}
+        assert should_continue(state) == "end"
+
+    def test_returns_continue_when_status_missing(self):
+        from docmind.library.pipeline.processing import should_continue
+
+        state = {}
+        assert should_continue(state) == "continue"
+
+    def test_returns_continue_when_status_ready(self):
+        from docmind.library.pipeline.processing import should_continue
+
+        state = {"status": "ready"}
+        assert should_continue(state) == "continue"
+
+
+class TestBuildProcessingGraph:
+    """Tests for build_processing_graph structure."""
+
+    def test_graph_compiles_without_error(self):
+        from docmind.library.pipeline.processing import build_processing_graph
+
+        graph = build_processing_graph()
+        assert graph is not None
+
+    def test_graph_is_invocable(self):
+        """The compiled graph has an invoke method."""
+        from docmind.library.pipeline.processing import build_processing_graph
+
+        graph = build_processing_graph()
+        assert hasattr(graph, "invoke")
+
+
+class TestRunProcessingPipeline:
+    """Tests for run_processing_pipeline entry point."""
+
+    @patch("docmind.library.pipeline.processing.processing_graph")
+    def test_invokes_graph_with_initial_state(self, mock_graph):
+        from docmind.library.pipeline.processing import run_processing_pipeline
+
+        initial_state = {"document_id": "test", "status": "processing"}
+        mock_graph.invoke.return_value = {"status": "ready", "extraction_id": "ext-123"}
+
+        result = run_processing_pipeline(initial_state)
+
+        mock_graph.invoke.assert_called_once_with(initial_state)
+        assert result["status"] == "ready"
+
+    @patch("docmind.library.pipeline.processing.processing_graph")
+    def test_returns_graph_result(self, mock_graph):
+        from docmind.library.pipeline.processing import run_processing_pipeline
+
+        expected = {"status": "ready", "extraction_id": "ext-456"}
+        mock_graph.invoke.return_value = expected
+
+        result = run_processing_pipeline({})
+        assert result == expected

--- a/backend/tests/unit/modules/documents/test_process_usecase.py
+++ b/backend/tests/unit/modules/documents/test_process_usecase.py
@@ -1,0 +1,197 @@
+"""
+Unit tests for DocumentUseCase.trigger_processing and _processing_stream.
+
+Pipeline, repository, and service are all mocked. Tests verify
+SSE event format, error handling, document status updates,
+and the async stream mechanics.
+"""
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_repo():
+    """Mock DocumentRepository."""
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=MagicMock(
+        storage_path="test/path/doc.pdf",
+        file_type="pdf",
+        id="doc-123",
+        status="uploaded",
+    ))
+    repo.update_status = AsyncMock()
+    return repo
+
+
+@pytest.fixture
+def mock_service():
+    """Mock DocumentService."""
+    service = MagicMock()
+    service.load_file_bytes = MagicMock(return_value=b"fake-pdf-bytes")
+    return service
+
+
+class TestTriggerProcessing:
+    """Tests for the trigger_processing method."""
+
+    def test_returns_async_generator(self, mock_repo, mock_service):
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        usecase = DocumentUseCase(service=mock_service, repo=mock_repo)
+        result = usecase.trigger_processing(document_id="doc-123")
+        assert result is not None
+
+
+class TestProcessingStream:
+    """Tests for _processing_stream SSE events."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.documents.usecase.run_processing_pipeline")
+    async def test_yields_sse_events(self, mock_pipeline, mock_repo, mock_service):
+        """SSE events follow the format: data: {JSON}\\n\\n"""
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        def fake_pipeline(state):
+            cb = state.get("progress_callback")
+            if cb:
+                cb("preprocess", 25, "Converting...")
+                cb("extract", 50, "Extracting...")
+                cb("complete", 100, "Done")
+            return {"status": "ready", "extraction_id": "ext-123"}
+
+        mock_pipeline.side_effect = fake_pipeline
+
+        usecase = DocumentUseCase(service=mock_service, repo=mock_repo)
+
+        events = []
+        async for event in usecase._processing_stream("doc-123", None):
+            events.append(event)
+
+        assert len(events) >= 3
+        for event in events:
+            assert event.startswith("data: ")
+            assert event.endswith("\n\n")
+            payload = json.loads(event[len("data: "):-2])
+            assert "step" in payload
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.documents.usecase.run_processing_pipeline")
+    async def test_yields_error_event_on_pipeline_failure(
+        self, mock_pipeline, mock_repo, mock_service
+    ):
+        """If pipeline returns status='error', yields error SSE event."""
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        mock_pipeline.return_value = {
+            "status": "error",
+            "error_message": "VLM provider timed out",
+        }
+
+        usecase = DocumentUseCase(service=mock_service, repo=mock_repo)
+
+        events = []
+        async for event in usecase._processing_stream("doc-123", None):
+            events.append(event)
+
+        error_events = [
+            e for e in events
+            if "error" in json.loads(e[len("data: "):-2]).get("step", "")
+        ]
+        assert len(error_events) >= 1
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.documents.usecase.run_processing_pipeline")
+    async def test_updates_status_to_error_on_failure(
+        self, mock_pipeline, mock_repo, mock_service
+    ):
+        """Document status is updated to 'error' when pipeline fails."""
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        mock_pipeline.return_value = {
+            "status": "error",
+            "error_message": "Extraction failed",
+        }
+
+        usecase = DocumentUseCase(service=mock_service, repo=mock_repo)
+
+        async for _ in usecase._processing_stream("doc-123", None):
+            pass
+
+        mock_repo.update_status.assert_any_call("doc-123", "error")
+
+    @pytest.mark.asyncio
+    async def test_yields_error_when_document_not_found(self, mock_service):
+        """If document is not found, yields error event."""
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        repo = MagicMock()
+        repo.get_by_id = AsyncMock(return_value=None)
+
+        usecase = DocumentUseCase(service=mock_service, repo=repo)
+
+        events = []
+        async for event in usecase._processing_stream("nonexistent", None):
+            events.append(event)
+
+        assert len(events) >= 1
+        payload = json.loads(events[0][len("data: "):-2])
+        assert payload["step"] == "error"
+        assert "not found" in payload["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_yields_error_when_file_load_fails(self, mock_repo):
+        """If file loading fails, yields error event."""
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        service = MagicMock()
+        service.load_file_bytes = MagicMock(side_effect=RuntimeError("Storage unavailable"))
+
+        usecase = DocumentUseCase(service=service, repo=mock_repo)
+
+        events = []
+        async for event in usecase._processing_stream("doc-123", None):
+            events.append(event)
+
+        assert len(events) >= 1
+        payload = json.loads(events[0][len("data: "):-2])
+        assert payload["step"] == "error"
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.documents.usecase.run_processing_pipeline")
+    async def test_updates_status_to_processing_before_pipeline(
+        self, mock_pipeline, mock_repo, mock_service
+    ):
+        """Document status is set to 'processing' before pipeline starts."""
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        mock_pipeline.return_value = {"status": "ready"}
+
+        usecase = DocumentUseCase(service=mock_service, repo=mock_repo)
+
+        async for _ in usecase._processing_stream("doc-123", None):
+            pass
+
+        mock_repo.update_status.assert_any_call("doc-123", "processing")
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.documents.usecase.run_processing_pipeline")
+    async def test_passes_template_type_in_initial_state(
+        self, mock_pipeline, mock_repo, mock_service
+    ):
+        """template_type from ProcessRequest is passed to pipeline initial state."""
+        from docmind.modules.documents.usecase import DocumentUseCase
+
+        def capture_state(state):
+            capture_state.captured = state
+            return {"status": "ready"}
+
+        mock_pipeline.side_effect = capture_state
+
+        usecase = DocumentUseCase(service=mock_service, repo=mock_repo)
+
+        async for _ in usecase._processing_stream("doc-123", "invoice"):
+            pass
+
+        assert capture_state.captured["template_type"] == "invoice"


### PR DESCRIPTION
## Summary
- Add `should_continue`, `build_processing_graph`, `run_processing_pipeline` using LangGraph StateGraph
- Replace `_processing_stream` stub with real async queue-based SSE stream
- Pipeline runs in background thread via `asyncio.to_thread`
- SSE events: progress, heartbeat (30s), error, complete
- Document status updated to processing/error appropriately

## Test plan
- [x] 8 pipeline graph tests (should_continue, build, run)
- [x] 8 usecase SSE stream tests (events, errors, status updates, template passthrough)
- [x] All 318 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)