### PR TITLE
feat(extractions): repository + usecase #16

### DIFF
--- a/backend/src/docmind/modules/extractions/repositories.py
+++ b/backend/src/docmind/modules/extractions/repositories.py
@@ -1,16 +1,72 @@
-"""docmind/modules/extractions/repositories.py — Stub."""
+"""
+docmind/modules/extractions/repositories.py
+
+Extraction database operations via SQLAlchemy.
+"""
+
+from sqlalchemy import select
 
 from docmind.core.logging import get_logger
+from docmind.dbase.psql.core.session import AsyncSessionLocal
+from docmind.dbase.psql.models import AuditEntry, ExtractedField, Extraction
 
 logger = get_logger(__name__)
 
 
 class ExtractionRepository:
-    async def get_latest_extraction(self, document_id: str):
-        raise NotImplementedError
+    """Repository for extraction query operations via SQLAlchemy."""
 
-    async def get_fields(self, extraction_id: str):
-        raise NotImplementedError
+    async def get_latest_extraction(self, document_id: str) -> Extraction | None:
+        """Get the most recent extraction for a document.
 
-    async def get_audit_trail(self, extraction_id: str):
-        raise NotImplementedError
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            Latest Extraction ORM instance, or None.
+        """
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(Extraction)
+                .where(Extraction.document_id == document_id)
+                .order_by(Extraction.created_at.desc())
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
+
+    async def get_fields(self, extraction_id: str) -> list[ExtractedField]:
+        """Get all extracted fields for an extraction, ordered by page and position.
+
+        Args:
+            extraction_id: The extraction ID.
+
+        Returns:
+            List of ExtractedField ORM instances.
+        """
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(ExtractedField)
+                .where(ExtractedField.extraction_id == extraction_id)
+                .order_by(ExtractedField.page_number, ExtractedField.id)
+            )
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
+
+    async def get_audit_trail(self, extraction_id: str) -> list[AuditEntry]:
+        """Get audit entries for an extraction, ordered by step_order.
+
+        Args:
+            extraction_id: The extraction ID.
+
+        Returns:
+            List of AuditEntry ORM instances.
+        """
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(AuditEntry)
+                .where(AuditEntry.extraction_id == extraction_id)
+                .order_by(AuditEntry.step_order)
+            )
+            result = await session.execute(stmt)
+            return list(result.scalars().all())

--- a/backend/src/docmind/modules/extractions/usecase.py
+++ b/backend/src/docmind/modules/extractions/usecase.py
@@ -1,26 +1,181 @@
-"""docmind/modules/extractions/usecase.py — Stub."""
+"""
+docmind/modules/extractions/usecase.py
+
+Extraction use case — orchestrates repository calls and maps to response schemas.
+"""
 
 from docmind.core.logging import get_logger
 
+from .repositories import ExtractionRepository
 from .schemas import (
     AuditEntryResponse,
     ComparisonResponse,
+    ExtractedFieldResponse,
     ExtractionResponse,
     OverlayRegion,
 )
 
 logger = get_logger(__name__)
 
+# Confidence color thresholds
+_HIGH_CONFIDENCE = 0.8
+_MEDIUM_CONFIDENCE = 0.5
+_COLOR_HIGH = "#22c55e"      # green
+_COLOR_MEDIUM = "#f59e0b"    # amber
+_COLOR_LOW = "#ef4444"       # red
+
+
+def _confidence_color(confidence: float) -> str:
+    """Map confidence score to a color hex code."""
+    if confidence >= _HIGH_CONFIDENCE:
+        return _COLOR_HIGH
+    if confidence >= _MEDIUM_CONFIDENCE:
+        return _COLOR_MEDIUM
+    return _COLOR_LOW
+
 
 class ExtractionUseCase:
-    def get_extraction(self, document_id: str) -> ExtractionResponse | None:
-        return None
+    """Orchestrates extraction operations across repository layer."""
 
-    def get_audit_trail(self, document_id: str) -> list[AuditEntryResponse]:
-        return []
+    def __init__(self, repo: ExtractionRepository | None = None) -> None:
+        self.repo = repo or ExtractionRepository()
 
-    def get_overlay_data(self, document_id: str) -> list[OverlayRegion]:
-        return []
+    async def get_extraction(self, document_id: str) -> ExtractionResponse | None:
+        """Get the latest extraction with fields for a document.
 
-    def get_comparison(self, document_id: str) -> ComparisonResponse | None:
-        return None
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            ExtractionResponse with nested fields, or None.
+        """
+        extraction = await self.repo.get_latest_extraction(document_id)
+        if extraction is None:
+            return None
+
+        fields = await self.repo.get_fields(str(extraction.id))
+
+        field_responses = [
+            ExtractedFieldResponse(
+                id=str(f.id),
+                field_type=f.field_type,
+                field_key=f.field_key,
+                field_value=f.field_value,
+                page_number=f.page_number,
+                bounding_box=f.bounding_box or {},
+                confidence=f.confidence,
+                vlm_confidence=f.vlm_confidence,
+                cv_quality_score=f.cv_quality_score,
+                is_required=f.is_required,
+                is_missing=f.is_missing,
+            )
+            for f in fields
+        ]
+
+        return ExtractionResponse(
+            id=str(extraction.id),
+            document_id=str(extraction.document_id),
+            mode=extraction.mode,
+            template_type=extraction.template_type,
+            fields=field_responses,
+            processing_time_ms=extraction.processing_time_ms,
+            created_at=extraction.created_at,
+        )
+
+    async def get_audit_trail(self, document_id: str) -> list[AuditEntryResponse]:
+        """Get audit trail for the latest extraction of a document.
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            List of AuditEntryResponse, or empty list.
+        """
+        extraction = await self.repo.get_latest_extraction(document_id)
+        if extraction is None:
+            return []
+
+        entries = await self.repo.get_audit_trail(str(extraction.id))
+
+        return [
+            AuditEntryResponse(
+                step_name=e.step_name,
+                step_order=e.step_order,
+                input_summary=e.input_summary or {},
+                output_summary=e.output_summary or {},
+                parameters=e.parameters or {},
+                duration_ms=e.duration_ms,
+            )
+            for e in entries
+        ]
+
+    async def get_overlay_data(self, document_id: str) -> list[OverlayRegion]:
+        """Get confidence overlay regions for the latest extraction.
+
+        Maps each extracted field's bounding box to an OverlayRegion
+        with color coding based on confidence level.
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            List of OverlayRegion, or empty list.
+        """
+        extraction = await self.repo.get_latest_extraction(document_id)
+        if extraction is None:
+            return []
+
+        fields = await self.repo.get_fields(str(extraction.id))
+
+        regions = []
+        for f in fields:
+            bbox = f.bounding_box or {}
+            regions.append(OverlayRegion(
+                x=bbox.get("x", 0.0),
+                y=bbox.get("y", 0.0),
+                width=bbox.get("width", 0.0),
+                height=bbox.get("height", 0.0),
+                confidence=f.confidence,
+                color=_confidence_color(f.confidence),
+                tooltip=f"{f.field_key}: {f.field_value}" if f.field_key else None,
+            ))
+        return regions
+
+    async def get_comparison(self, document_id: str) -> ComparisonResponse | None:
+        """Get comparison data for the latest extraction.
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            ComparisonResponse or None if no extraction exists.
+        """
+        extraction = await self.repo.get_latest_extraction(document_id)
+        if extraction is None:
+            return None
+
+        fields = await self.repo.get_fields(str(extraction.id))
+
+        field_responses = [
+            ExtractedFieldResponse(
+                id=str(f.id),
+                field_type=f.field_type,
+                field_key=f.field_key,
+                field_value=f.field_value,
+                page_number=f.page_number,
+                bounding_box=f.bounding_box or {},
+                confidence=f.confidence,
+                vlm_confidence=f.vlm_confidence,
+                cv_quality_score=f.cv_quality_score,
+                is_required=f.is_required,
+                is_missing=f.is_missing,
+            )
+            for f in fields
+        ]
+
+        return ComparisonResponse(
+            enhanced_fields=field_responses,
+            raw_fields=[],
+            corrected=[],
+            added=[],
+        )

--- a/backend/tests/unit/modules/extractions/test_extraction_repository.py
+++ b/backend/tests/unit/modules/extractions/test_extraction_repository.py
@@ -1,0 +1,157 @@
+"""Unit tests for ExtractionRepository."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_extraction():
+    """Mock Extraction ORM object."""
+    ext = MagicMock()
+    ext.id = "ext-001"
+    ext.document_id = "doc-001"
+    ext.mode = "general"
+    ext.template_type = None
+    ext.processing_time_ms = 1200
+    return ext
+
+
+@pytest.fixture
+def mock_fields():
+    """Mock ExtractedField ORM objects."""
+    f1 = MagicMock()
+    f1.field_key = "invoice_number"
+    f2 = MagicMock()
+    f2.field_key = "total_amount"
+    return [f1, f2]
+
+
+@pytest.fixture
+def mock_audit_entries():
+    """Mock AuditEntry ORM objects."""
+    e1 = MagicMock()
+    e1.step_name = "preprocess"
+    e1.step_order = 1
+    e2 = MagicMock()
+    e2.step_name = "extract"
+    e2.step_order = 2
+    return [e1, e2]
+
+
+class TestExtractionRepositoryGetLatest:
+    """Tests for ExtractionRepository.get_latest_extraction."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.extractions.repositories.AsyncSessionLocal")
+    async def test_returns_latest_extraction(self, mock_session_factory, mock_extraction):
+        from docmind.modules.extractions.repositories import ExtractionRepository
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_extraction
+        mock_session.execute.return_value = mock_result
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ExtractionRepository()
+        result = await repo.get_latest_extraction("doc-001")
+
+        assert result is not None
+        assert result.document_id == "doc-001"
+        mock_session.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.extractions.repositories.AsyncSessionLocal")
+    async def test_returns_none_when_no_extraction(self, mock_session_factory):
+        from docmind.modules.extractions.repositories import ExtractionRepository
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        mock_session.execute.return_value = mock_result
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ExtractionRepository()
+        result = await repo.get_latest_extraction("nonexistent-doc")
+
+        assert result is None
+
+
+class TestExtractionRepositoryGetFields:
+    """Tests for ExtractionRepository.get_fields."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.extractions.repositories.AsyncSessionLocal")
+    async def test_returns_fields_for_extraction(self, mock_session_factory, mock_fields):
+        from docmind.modules.extractions.repositories import ExtractionRepository
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = mock_fields
+        mock_session.execute.return_value = mock_result
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ExtractionRepository()
+        fields = await repo.get_fields("ext-001")
+
+        assert len(fields) == 2
+        assert fields[0].field_key == "invoice_number"
+        assert fields[1].field_key == "total_amount"
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.extractions.repositories.AsyncSessionLocal")
+    async def test_returns_empty_list_when_no_fields(self, mock_session_factory):
+        from docmind.modules.extractions.repositories import ExtractionRepository
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = mock_result
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ExtractionRepository()
+        fields = await repo.get_fields("ext-nonexistent")
+
+        assert fields == []
+
+
+class TestExtractionRepositoryGetAuditTrail:
+    """Tests for ExtractionRepository.get_audit_trail."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.extractions.repositories.AsyncSessionLocal")
+    async def test_returns_audit_entries_ordered(self, mock_session_factory, mock_audit_entries):
+        from docmind.modules.extractions.repositories import ExtractionRepository
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = mock_audit_entries
+        mock_session.execute.return_value = mock_result
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ExtractionRepository()
+        entries = await repo.get_audit_trail("ext-001")
+
+        assert len(entries) == 2
+        assert entries[0].step_name == "preprocess"
+        assert entries[1].step_name == "extract"
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.extractions.repositories.AsyncSessionLocal")
+    async def test_returns_empty_list_when_no_audit(self, mock_session_factory):
+        from docmind.modules.extractions.repositories import ExtractionRepository
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        mock_session.execute.return_value = mock_result
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ExtractionRepository()
+        entries = await repo.get_audit_trail("ext-nonexistent")
+
+        assert entries == []

--- a/backend/tests/unit/modules/extractions/test_extraction_usecase.py
+++ b/backend/tests/unit/modules/extractions/test_extraction_usecase.py
@@ -1,0 +1,155 @@
+"""Unit tests for ExtractionUseCase."""
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from docmind.modules.extractions.schemas import (
+    AuditEntryResponse,
+    ExtractionResponse,
+    OverlayRegion,
+)
+
+
+@pytest.fixture
+def mock_extraction_orm():
+    """Mock Extraction ORM object."""
+    ext = MagicMock()
+    ext.id = "ext-001"
+    ext.document_id = "doc-001"
+    ext.mode = "general"
+    ext.template_type = None
+    ext.processing_time_ms = 1200
+    ext.created_at = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    return ext
+
+
+@pytest.fixture
+def mock_field_orm():
+    """Mock ExtractedField ORM object."""
+    field = MagicMock()
+    field.id = "field-001"
+    field.field_type = "key_value"
+    field.field_key = "vendor_name"
+    field.field_value = "Acme Corp"
+    field.page_number = 1
+    field.bounding_box = {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05}
+    field.confidence = 0.92
+    field.vlm_confidence = 0.90
+    field.cv_quality_score = 0.88
+    field.is_required = True
+    field.is_missing = False
+    return field
+
+
+@pytest.fixture
+def mock_audit_orm():
+    """Mock AuditEntry ORM object."""
+    entry = MagicMock()
+    entry.step_name = "preprocess"
+    entry.step_order = 1
+    entry.input_summary = {"file_type": "pdf"}
+    entry.output_summary = {"page_count": 2}
+    entry.parameters = {"dpi": 300}
+    entry.duration_ms = 350
+    return entry
+
+
+class TestExtractionUseCaseGetExtraction:
+    """Tests for ExtractionUseCase.get_extraction."""
+
+    @pytest.mark.asyncio
+    async def test_returns_extraction_response_when_found(self, mock_extraction_orm, mock_field_orm):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = mock_extraction_orm
+        usecase.repo.get_fields.return_value = [mock_field_orm]
+
+        result = await usecase.get_extraction("doc-001")
+
+        assert result is not None
+        assert isinstance(result, ExtractionResponse)
+        assert result.id == "ext-001"
+        assert result.document_id == "doc-001"
+        assert len(result.fields) == 1
+        assert result.fields[0].field_key == "vendor_name"
+        usecase.repo.get_latest_extraction.assert_called_once_with("doc-001")
+        usecase.repo.get_fields.assert_called_once_with("ext-001")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_extraction(self):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = None
+
+        result = await usecase.get_extraction("nonexistent-doc")
+
+        assert result is None
+        usecase.repo.get_fields.assert_not_called()
+
+
+class TestExtractionUseCaseGetAuditTrail:
+    """Tests for ExtractionUseCase.get_audit_trail."""
+
+    @pytest.mark.asyncio
+    async def test_returns_audit_entries(self, mock_extraction_orm, mock_audit_orm):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = mock_extraction_orm
+        usecase.repo.get_audit_trail.return_value = [mock_audit_orm]
+
+        result = await usecase.get_audit_trail("doc-001")
+
+        assert len(result) == 1
+        assert isinstance(result[0], AuditEntryResponse)
+        assert result[0].step_name == "preprocess"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_extraction(self):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = None
+
+        result = await usecase.get_audit_trail("nonexistent-doc")
+
+        assert result == []
+
+
+class TestExtractionUseCaseGetOverlayData:
+    """Tests for ExtractionUseCase.get_overlay_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_overlay_regions(self, mock_extraction_orm, mock_field_orm):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = mock_extraction_orm
+        usecase.repo.get_fields.return_value = [mock_field_orm]
+
+        result = await usecase.get_overlay_data("doc-001")
+
+        assert len(result) == 1
+        assert isinstance(result[0], OverlayRegion)
+        assert result[0].confidence == 0.92
+        # Green for high confidence
+        assert result[0].color == "#22c55e"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_extraction(self):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = None
+
+        result = await usecase.get_overlay_data("nonexistent-doc")
+
+        assert result == []


### PR DESCRIPTION
## Summary
- Implement `ExtractionRepository` with SQLAlchemy async queries
- Implement `ExtractionUseCase` with ORM-to-schema mapping
- Confidence color coding: green (>=0.8), amber (>=0.5), red (<0.5)

## Test plan
- [x] 6 repository tests (get_latest, get_fields, get_audit_trail + empty cases)
- [x] 6 usecase tests (get_extraction, get_audit_trail, get_overlay_data + empty cases)
- [x] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)