### PR TITLE
feat(audit): AuditRecorder + audit trail retrieval #17

### DIFF
--- a/backend/src/docmind/shared/audit.py
+++ b/backend/src/docmind/shared/audit.py
@@ -1,0 +1,115 @@
+"""
+docmind/shared/audit.py
+
+Audit trail recording utility for pipeline steps.
+"""
+
+import time
+from contextlib import asynccontextmanager
+from typing import Any
+
+from docmind.core.logging import get_logger
+from docmind.dbase.psql.core.session import AsyncSessionLocal
+from docmind.dbase.psql.models import AuditEntry
+
+logger = get_logger(__name__)
+
+
+class _StepContext:
+    """Context for a pipeline step, used by AuditRecorder.step()."""
+
+    def __init__(self) -> None:
+        self._input_summary: dict[str, Any] = {}
+        self._output_summary: dict[str, Any] = {}
+
+    def set_input(self, summary: dict[str, Any]) -> None:
+        self._input_summary = summary
+
+    def set_output(self, summary: dict[str, Any]) -> None:
+        self._output_summary = summary
+
+
+class AuditRecorder:
+    """Records audit entries for pipeline steps.
+
+    Each entry is persisted to the database via SQLAlchemy.
+    Recording failures are logged but never raised.
+    """
+
+    def __init__(self, extraction_id: str) -> None:
+        self.extraction_id = extraction_id
+
+    async def record(
+        self,
+        step_name: str,
+        step_order: int,
+        input_summary: dict[str, Any],
+        output_summary: dict[str, Any],
+        parameters: dict[str, Any],
+        duration_ms: int,
+    ) -> None:
+        """Record a single audit entry.
+
+        Args:
+            step_name: Pipeline step name (e.g. "preprocess").
+            step_order: Ordering index (1-based).
+            input_summary: Summary of step inputs.
+            output_summary: Summary of step outputs.
+            parameters: Step configuration parameters.
+            duration_ms: Step execution time in milliseconds.
+        """
+        try:
+            async with AsyncSessionLocal() as session:
+                entry = AuditEntry(
+                    extraction_id=self.extraction_id,
+                    step_name=step_name,
+                    step_order=step_order,
+                    input_summary=input_summary,
+                    output_summary=output_summary,
+                    parameters=parameters,
+                    duration_ms=duration_ms,
+                )
+                session.add(entry)
+                await session.commit()
+        except Exception as e:
+            logger.warning(
+                "audit_record_failed",
+                extraction_id=self.extraction_id,
+                step_name=step_name,
+                error=str(e),
+            )
+
+    @asynccontextmanager
+    async def step(
+        self,
+        step_name: str,
+        step_order: int,
+        parameters: dict[str, Any] | None = None,
+    ):
+        """Context manager that auto-times a pipeline step.
+
+        Usage:
+            async with recorder.step("preprocess", 1, {"dpi": 300}) as ctx:
+                ctx.set_input({"file_type": "pdf"})
+                # ... do work ...
+                ctx.set_output({"page_count": 2})
+
+        Args:
+            step_name: Pipeline step name.
+            step_order: Ordering index.
+            parameters: Step configuration parameters.
+        """
+        ctx = _StepContext()
+        start = time.perf_counter()
+        try:
+            yield ctx
+        finally:
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            await self.record(
+                step_name=step_name,
+                step_order=step_order,
+                input_summary=ctx._input_summary,
+                output_summary=ctx._output_summary,
+                parameters=parameters or {},
+                duration_ms=elapsed_ms,
+            )

--- a/backend/tests/unit/modules/extractions/test_audit_trail.py
+++ b/backend/tests/unit/modules/extractions/test_audit_trail.py
@@ -1,0 +1,82 @@
+"""Unit tests for audit trail retrieval through usecase."""
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+from docmind.modules.extractions.schemas import AuditEntryResponse
+
+
+@pytest.fixture
+def mock_extraction_orm():
+    ext = MagicMock()
+    ext.id = "ext-001"
+    ext.document_id = "doc-001"
+    ext.mode = "general"
+    ext.template_type = None
+    ext.processing_time_ms = 1200
+    ext.created_at = datetime(2026, 1, 15, tzinfo=timezone.utc)
+    return ext
+
+
+@pytest.fixture
+def mock_audit_entries():
+    entries = []
+    for name, order, dur in [
+        ("preprocess", 1, 350),
+        ("extract", 2, 800),
+        ("postprocess", 3, 150),
+        ("store", 4, 50),
+    ]:
+        e = MagicMock()
+        e.step_name = name
+        e.step_order = order
+        e.input_summary = {"step": name}
+        e.output_summary = {"done": True}
+        e.parameters = {}
+        e.duration_ms = dur
+        entries.append(e)
+    return entries
+
+
+class TestAuditTrailRetrieval:
+
+    @pytest.mark.asyncio
+    async def test_get_audit_trail_returns_ordered_entries(self, mock_extraction_orm, mock_audit_entries):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = mock_extraction_orm
+        usecase.repo.get_audit_trail.return_value = mock_audit_entries
+
+        result = await usecase.get_audit_trail("doc-001")
+
+        assert len(result) == 4
+        assert all(isinstance(r, AuditEntryResponse) for r in result)
+        assert [r.step_name for r in result] == ["preprocess", "extract", "postprocess", "store"]
+        assert [r.step_order for r in result] == [1, 2, 3, 4]
+
+    @pytest.mark.asyncio
+    async def test_get_audit_trail_empty_when_no_extraction(self):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = None
+
+        result = await usecase.get_audit_trail("nonexistent-doc")
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_get_audit_trail_empty_when_no_entries(self, mock_extraction_orm):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = mock_extraction_orm
+        usecase.repo.get_audit_trail.return_value = []
+
+        result = await usecase.get_audit_trail("doc-001")
+
+        assert result == []

--- a/backend/tests/unit/shared/test_audit_recorder.py
+++ b/backend/tests/unit/shared/test_audit_recorder.py
@@ -1,0 +1,81 @@
+"""Unit tests for AuditRecorder."""
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+
+class TestAuditRecorder:
+    """Tests for the AuditRecorder utility."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.shared.audit.AsyncSessionLocal")
+    async def test_record_creates_audit_entry(self, mock_session_factory):
+        from docmind.shared.audit import AuditRecorder
+
+        mock_session = AsyncMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        recorder = AuditRecorder(extraction_id="ext-001")
+        await recorder.record(
+            step_name="preprocess",
+            step_order=1,
+            input_summary={"file_type": "pdf"},
+            output_summary={"page_count": 3},
+            parameters={"dpi": 300},
+            duration_ms=450,
+        )
+
+        mock_session.add.assert_called_once()
+        added_entry = mock_session.add.call_args[0][0]
+        assert added_entry.extraction_id == "ext-001"
+        assert added_entry.step_name == "preprocess"
+        assert added_entry.step_order == 1
+        assert added_entry.duration_ms == 450
+        mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    @patch("docmind.shared.audit.AsyncSessionLocal")
+    async def test_record_does_not_raise_on_db_error(self, mock_session_factory):
+        from docmind.shared.audit import AuditRecorder
+
+        mock_session = AsyncMock()
+        mock_session.commit.side_effect = Exception("DB connection lost")
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        recorder = AuditRecorder(extraction_id="ext-001")
+
+        # Should not raise
+        await recorder.record(
+            step_name="extract",
+            step_order=2,
+            input_summary={},
+            output_summary={},
+            parameters={},
+            duration_ms=100,
+        )
+
+    @pytest.mark.asyncio
+    @patch("docmind.shared.audit.AsyncSessionLocal")
+    async def test_step_context_manager_measures_duration(self, mock_session_factory):
+        from docmind.shared.audit import AuditRecorder
+
+        mock_session = AsyncMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        recorder = AuditRecorder(extraction_id="ext-001")
+
+        async with recorder.step("preprocess", step_order=1, parameters={"dpi": 300}) as ctx:
+            ctx.set_input({"file_type": "pdf"})
+            await asyncio.sleep(0.05)
+            ctx.set_output({"page_count": 2})
+
+        mock_session.add.assert_called_once()
+        added_entry = mock_session.add.call_args[0][0]
+        assert added_entry.step_name == "preprocess"
+        assert added_entry.duration_ms >= 40
+        assert added_entry.input_summary == {"file_type": "pdf"}
+        assert added_entry.output_summary == {"page_count": 2}


### PR DESCRIPTION
## Summary
- Add `AuditRecorder` in `docmind/shared/audit.py` with `record()` and `step()` context manager
- Audit recording failures logged as warnings, never raised
- `step()` auto-times with `time.perf_counter()`
- Audit trail retrieval already implemented in #16, additional tests added

## Test plan
- [x] 3 AuditRecorder tests (record, error handling, step timing)
- [x] 3 audit trail retrieval tests (ordered entries, empty cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)