### PR TITLE
feat(extractions): confidence overlay generation #18

### DIFF
--- a/backend/src/docmind/modules/extractions/apiv1/handler.py
+++ b/backend/src/docmind/modules/extractions/apiv1/handler.py
@@ -22,7 +22,7 @@ async def get_extraction(
     document_id: str, current_user: dict = Depends(get_current_user)
 ):
     usecase = ExtractionUseCase()
-    extraction = usecase.get_extraction(document_id=document_id)
+    extraction = await usecase.get_extraction(document_id=document_id)
     if extraction is None:
         raise HTTPException(status_code=404, detail="Extraction not found")
     return extraction
@@ -33,7 +33,7 @@ async def get_audit_trail(
     document_id: str, current_user: dict = Depends(get_current_user)
 ):
     usecase = ExtractionUseCase()
-    return usecase.get_audit_trail(document_id=document_id)
+    return await usecase.get_audit_trail(document_id=document_id)
 
 
 @router.get("/{document_id}/overlay", response_model=list[OverlayRegion])
@@ -41,7 +41,7 @@ async def get_overlay_data(
     document_id: str, current_user: dict = Depends(get_current_user)
 ):
     usecase = ExtractionUseCase()
-    return usecase.get_overlay_data(document_id=document_id)
+    return await usecase.get_overlay_data(document_id=document_id)
 
 
 @router.get("/{document_id}/comparison", response_model=ComparisonResponse)
@@ -49,7 +49,7 @@ async def get_comparison(
     document_id: str, current_user: dict = Depends(get_current_user)
 ):
     usecase = ExtractionUseCase()
-    comparison = usecase.get_comparison(document_id=document_id)
+    comparison = await usecase.get_comparison(document_id=document_id)
     if comparison is None:
         raise HTTPException(status_code=404, detail="Comparison not available")
     return comparison

--- a/backend/tests/unit/modules/extractions/test_overlay.py
+++ b/backend/tests/unit/modules/extractions/test_overlay.py
@@ -1,0 +1,85 @@
+"""Unit tests for confidence overlay generation."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from docmind.modules.extractions.schemas import OverlayRegion
+from docmind.modules.extractions.services import ExtractionService
+
+
+class TestExtractionServiceConfidenceColor:
+    """Tests for ExtractionService.confidence_color."""
+
+    def test_high_confidence_returns_green(self):
+        assert ExtractionService.confidence_color(0.95) == "#22c55e"
+        assert ExtractionService.confidence_color(0.80) == "#22c55e"
+
+    def test_medium_confidence_returns_amber(self):
+        assert ExtractionService.confidence_color(0.79) == "#eab308"
+        assert ExtractionService.confidence_color(0.50) == "#eab308"
+
+    def test_low_confidence_returns_red(self):
+        assert ExtractionService.confidence_color(0.49) == "#ef4444"
+        assert ExtractionService.confidence_color(0.0) == "#ef4444"
+
+
+class TestExtractionServiceBuildOverlayRegion:
+    """Tests for ExtractionService.build_overlay_region."""
+
+    def test_builds_region_from_field(self):
+        field = {
+            "field_key": "total",
+            "field_value": "$500",
+            "confidence": 0.9,
+            "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+        }
+        region = ExtractionService.build_overlay_region(field)
+        assert region is not None
+        assert region["x"] == 0.1
+        assert region["confidence"] == 0.9
+        assert region["color"] == "#22c55e"
+        assert "total" in region["tooltip"]
+
+    def test_returns_none_for_empty_bbox(self):
+        field = {"confidence": 0.9, "bounding_box": {}}
+        assert ExtractionService.build_overlay_region(field) is None
+
+    def test_returns_none_for_missing_bbox(self):
+        field = {"confidence": 0.9}
+        assert ExtractionService.build_overlay_region(field) is None
+
+
+class TestOverlayDataUsecase:
+    """Tests for ExtractionUseCase.get_overlay_data."""
+
+    @pytest.mark.asyncio
+    async def test_returns_overlay_regions_with_colors(self):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        mock_ext = MagicMock(id="ext-001")
+        mock_field = MagicMock(
+            bounding_box={"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+            confidence=0.45,
+            field_key="amount",
+            field_value="$100",
+        )
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = mock_ext
+        usecase.repo.get_fields.return_value = [mock_field]
+
+        result = await usecase.get_overlay_data("doc-001")
+
+        assert len(result) == 1
+        assert isinstance(result[0], OverlayRegion)
+        assert result[0].color == "#ef4444"  # red for low confidence
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_no_extraction(self):
+        from docmind.modules.extractions.usecase import ExtractionUseCase
+
+        usecase = ExtractionUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_latest_extraction.return_value = None
+
+        result = await usecase.get_overlay_data("nonexistent")
+        assert result == []


### PR DESCRIPTION
## Summary
- Add tests for `ExtractionService` confidence color mapping and overlay region building
- Fix extraction handler to `await` async usecase methods
- Test overlay data pipeline through usecase layer

## Test plan
- [x] 3 service tests (color thresholds)
- [x] 3 service tests (overlay region building)
- [x] 2 usecase tests (overlay with colors, empty case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)