### PR TITLE
feat(templates): TemplateService JSON loading #20

### DIFF
--- a/backend/src/docmind/modules/templates/apiv1/handler.py
+++ b/backend/src/docmind/modules/templates/apiv1/handler.py
@@ -4,50 +4,15 @@ from fastapi import APIRouter
 
 from docmind.core.logging import get_logger
 
-from ..schemas import TemplateListResponse, TemplateResponse
+from ..schemas import TemplateListResponse
+from ..services import TemplateService
 
 logger = get_logger(__name__)
 router = APIRouter()
 
-TEMPLATES = [
-    TemplateResponse(
-        type="invoice",
-        name="Invoice",
-        description="Commercial invoices with line items, totals, and vendor info",
-        required_fields=["invoice_number", "date", "total_amount", "vendor_name"],
-        optional_fields=["due_date", "tax_amount", "line_items", "purchase_order"],
-    ),
-    TemplateResponse(
-        type="receipt",
-        name="Receipt",
-        description="Purchase receipts with itemized costs",
-        required_fields=["date", "total_amount", "merchant_name"],
-        optional_fields=["tax_amount", "payment_method", "line_items"],
-    ),
-    TemplateResponse(
-        type="medical_report",
-        name="Medical Report",
-        description="Medical lab reports and diagnostic documents",
-        required_fields=["patient_name", "report_date", "report_type"],
-        optional_fields=["doctor_name", "diagnosis", "test_results", "facility"],
-    ),
-    TemplateResponse(
-        type="contract",
-        name="Contract",
-        description="Legal contracts and agreements",
-        required_fields=["parties", "effective_date", "contract_type"],
-        optional_fields=["expiry_date", "terms", "signatures", "governing_law"],
-    ),
-    TemplateResponse(
-        type="id_document",
-        name="ID Document",
-        description="Government-issued identification documents",
-        required_fields=["full_name", "document_number", "date_of_birth"],
-        optional_fields=["expiry_date", "nationality", "address", "issuing_authority"],
-    ),
-]
+_service = TemplateService()
 
 
 @router.get("", response_model=TemplateListResponse)
 async def list_templates():
-    return TemplateListResponse(items=TEMPLATES)
+    return TemplateListResponse(items=_service.list_templates())

--- a/backend/src/docmind/modules/templates/services.py
+++ b/backend/src/docmind/modules/templates/services.py
@@ -1,5 +1,68 @@
-"""docmind/modules/templates/services.py — Stub."""
+"""
+docmind/modules/templates/services.py
+
+Template service — loads and serves predefined document extraction templates
+from JSON files in data/templates/.
+"""
+
+import json
+from pathlib import Path
+
+from docmind.core.logging import get_logger
+
+from .schemas import TemplateResponse
+
+logger = get_logger(__name__)
+
+_DEFAULT_TEMPLATES_DIR = Path(__file__).resolve().parents[4] / "data" / "templates"
 
 
 class TemplateService:
-    pass
+    """Service for loading and querying extraction templates."""
+
+    def __init__(self, templates_dir: Path | None = None) -> None:
+        self._templates_dir = templates_dir or _DEFAULT_TEMPLATES_DIR
+        self._templates: list[TemplateResponse] = []
+        self._loaded = False
+
+    def _load(self) -> None:
+        """Load templates from JSON files on first access."""
+        if self._loaded:
+            return
+        self._loaded = True
+
+        if not self._templates_dir.is_dir():
+            logger.warning("templates_dir_not_found", path=str(self._templates_dir))
+            return
+
+        for path in sorted(self._templates_dir.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+                template = TemplateResponse(**data)
+                self._templates.append(template)
+            except (json.JSONDecodeError, TypeError, Exception) as e:
+                logger.warning(
+                    "template_load_failed",
+                    file=path.name,
+                    error=str(e),
+                )
+
+    def list_templates(self) -> list[TemplateResponse]:
+        """Return all available templates."""
+        self._load()
+        return list(self._templates)
+
+    def get_template(self, template_type: str) -> TemplateResponse | None:
+        """Get a template by type name.
+
+        Args:
+            template_type: The template type (e.g. "invoice").
+
+        Returns:
+            TemplateResponse or None if not found.
+        """
+        self._load()
+        for t in self._templates:
+            if t.type == template_type:
+                return t
+        return None

--- a/backend/tests/unit/modules/templates/test_template_service.py
+++ b/backend/tests/unit/modules/templates/test_template_service.py
@@ -1,0 +1,99 @@
+"""Unit tests for TemplateService."""
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from docmind.modules.templates.schemas import TemplateResponse
+
+
+class TestTemplateService:
+    """Tests for TemplateService loading templates from JSON files."""
+
+    def _create_template_dir(self, tmp_path: Path) -> Path:
+        """Create a temp directory with template JSON files."""
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+
+        invoice = {
+            "type": "invoice",
+            "name": "Invoice",
+            "description": "Commercial invoices",
+            "required_fields": ["invoice_number", "date", "total_amount", "vendor_name"],
+            "optional_fields": ["due_date", "tax_amount"],
+        }
+        (templates_dir / "invoice.json").write_text(json.dumps(invoice))
+
+        receipt = {
+            "type": "receipt",
+            "name": "Receipt",
+            "description": "Purchase receipts",
+            "required_fields": ["date", "total_amount", "merchant_name"],
+            "optional_fields": ["tax_amount", "payment_method"],
+        }
+        (templates_dir / "receipt.json").write_text(json.dumps(receipt))
+
+        return templates_dir
+
+    def test_loads_templates_from_directory(self, tmp_path):
+        from docmind.modules.templates.services import TemplateService
+
+        templates_dir = self._create_template_dir(tmp_path)
+        service = TemplateService(templates_dir=templates_dir)
+
+        templates = service.list_templates()
+        assert len(templates) == 2
+        types = {t.type for t in templates}
+        assert "invoice" in types
+        assert "receipt" in types
+
+    def test_templates_are_template_response(self, tmp_path):
+        from docmind.modules.templates.services import TemplateService
+
+        templates_dir = self._create_template_dir(tmp_path)
+        service = TemplateService(templates_dir=templates_dir)
+
+        templates = service.list_templates()
+        for t in templates:
+            assert isinstance(t, TemplateResponse)
+
+    def test_get_template_by_type(self, tmp_path):
+        from docmind.modules.templates.services import TemplateService
+
+        templates_dir = self._create_template_dir(tmp_path)
+        service = TemplateService(templates_dir=templates_dir)
+
+        result = service.get_template("invoice")
+        assert result is not None
+        assert result.type == "invoice"
+        assert "invoice_number" in result.required_fields
+
+    def test_get_template_returns_none_for_unknown(self, tmp_path):
+        from docmind.modules.templates.services import TemplateService
+
+        templates_dir = self._create_template_dir(tmp_path)
+        service = TemplateService(templates_dir=templates_dir)
+
+        result = service.get_template("unknown")
+        assert result is None
+
+    def test_skips_invalid_json_files(self, tmp_path):
+        from docmind.modules.templates.services import TemplateService
+
+        templates_dir = tmp_path / "templates"
+        templates_dir.mkdir()
+        (templates_dir / "bad.json").write_text("not json")
+        (templates_dir / "empty.json").write_text("{}")
+
+        service = TemplateService(templates_dir=templates_dir)
+        templates = service.list_templates()
+        # Both should be skipped (bad JSON and missing required fields)
+        assert len(templates) == 0
+
+    def test_returns_empty_when_no_directory(self, tmp_path):
+        from docmind.modules.templates.services import TemplateService
+
+        service = TemplateService(templates_dir=tmp_path / "nonexistent")
+        templates = service.list_templates()
+        assert templates == []

--- a/data/templates/contract.json
+++ b/data/templates/contract.json
@@ -1,1 +1,7 @@
-{}
+{
+  "type": "contract",
+  "name": "Contract",
+  "description": "Legal contracts and agreements",
+  "required_fields": ["parties", "effective_date", "contract_type"],
+  "optional_fields": ["expiry_date", "terms", "signatures", "governing_law"]
+}

--- a/data/templates/id_document.json
+++ b/data/templates/id_document.json
@@ -1,1 +1,7 @@
-{}
+{
+  "type": "id_document",
+  "name": "ID Document",
+  "description": "Government-issued identification documents",
+  "required_fields": ["full_name", "document_number", "date_of_birth"],
+  "optional_fields": ["expiry_date", "nationality", "address", "issuing_authority"]
+}

--- a/data/templates/invoice.json
+++ b/data/templates/invoice.json
@@ -1,1 +1,7 @@
-{}
+{
+  "type": "invoice",
+  "name": "Invoice",
+  "description": "Commercial invoices with line items, totals, and vendor info",
+  "required_fields": ["invoice_number", "date", "total_amount", "vendor_name"],
+  "optional_fields": ["due_date", "tax_amount", "line_items", "purchase_order"]
+}

--- a/data/templates/medical_report.json
+++ b/data/templates/medical_report.json
@@ -1,1 +1,7 @@
-{}
+{
+  "type": "medical_report",
+  "name": "Medical Report",
+  "description": "Medical lab reports and diagnostic documents",
+  "required_fields": ["patient_name", "report_date", "report_type"],
+  "optional_fields": ["doctor_name", "diagnosis", "test_results", "facility"]
+}

--- a/data/templates/receipt.json
+++ b/data/templates/receipt.json
@@ -1,1 +1,7 @@
-{}
+{
+  "type": "receipt",
+  "name": "Receipt",
+  "description": "Purchase receipts with itemized costs",
+  "required_fields": ["date", "total_amount", "merchant_name"],
+  "optional_fields": ["tax_amount", "payment_method", "line_items"]
+}


### PR DESCRIPTION
## Summary
- Implement `TemplateService` with JSON file loading from `data/templates/`
- Populate 5 template JSON files (previously empty `{}`)
- Replace hardcoded `TEMPLATES` list in handler with service
- Lazy loading, invalid files skipped with warning

## Test plan
- [x] 6 tests (load, type check, get by type, unknown, invalid JSON, no dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)