### PR TITLE
feat(chat): router + retrieve nodes with graph #23

### DIFF
--- a/backend/src/docmind/library/pipeline/chat.py
+++ b/backend/src/docmind/library/pipeline/chat.py
@@ -2,9 +2,11 @@
 docmind/library/pipeline/chat.py
 
 LangGraph StateGraph for the document chat agent.
-Stub implementation for scaffold.
+
+Nodes: router -> retrieve -> reason -> cite -> END.
 """
 
+import re
 from typing import Any, Callable, TypedDict
 
 from docmind.core.logging import get_logger
@@ -36,9 +38,303 @@ class ChatState(TypedDict):
     stream_callback: Callable | None
 
 
-def run_chat_pipeline(initial_state: dict, config: dict) -> dict:
+# --- Intent classification ---
+
+INTENT_PATTERNS: dict[str, list[str]] = {
+    "factual_lookup": [
+        r"\bwhat\s+is\b",
+        r"\bwhat\s+are\b",
+        r"\bhow\s+much\b",
+        r"\bhow\s+many\b",
+        r"\bwhen\s+is\b",
+        r"\bwhen\s+was\b",
+        r"\bwho\s+is\b",
+        r"\btell\s+me\b",
+        r"\bfind\b",
+        r"\bshow\s+me\b",
+        r"\blist\b",
+        r"\bget\b",
+    ],
+    "reasoning": [
+        r"\bwhy\b",
+        r"\bexplain\b",
+        r"\bhow\s+does\b",
+        r"\bhow\s+do\b",
+        r"\breason\b",
+        r"\bcause\b",
+        r"\bbecause\b",
+        r"\banalyz",
+        r"\binterpret\b",
+    ],
+    "summarization": [
+        r"\bsummar",
+        r"\boverview\b",
+        r"\bbrief\b",
+        r"\bhighlight",
+        r"\bkey\s+points\b",
+        r"\bmain\s+points\b",
+        r"\btl;?dr\b",
+        r"\bin\s+short\b",
+    ],
+    "comparison": [
+        r"\bcompar",
+        r"\bdifference\b",
+        r"\bdiffer\b",
+        r"\bversus\b",
+        r"\bvs\.?\b",
+        r"\bbetween\b",
+        r"\bcontrast\b",
+        r"\bsimilar\b",
+    ],
+}
+
+_INTENT_LIMITS: dict[str, int] = {
+    "factual_lookup": 5,
+    "reasoning": 10,
+    "comparison": 15,
+    "summarization": 20,
+}
+
+_LOW_CONFIDENCE_THRESHOLD = 0.6
+_MAX_REQUERY_FIELDS = 3
+
+
+def _classify_intent(message: str) -> tuple[str, float]:
+    """Classify user message intent using regex pattern matching.
+
+    Args:
+        message: User's chat message.
+
+    Returns:
+        Tuple of (intent, confidence).
     """
-    Run the full chat pipeline.
-    Stub implementation — raises NotImplementedError.
+    if not message.strip():
+        return ("factual_lookup", 0.3)
+
+    lower = message.lower()
+    scores: dict[str, int] = {}
+
+    for intent, patterns in INTENT_PATTERNS.items():
+        count = sum(1 for p in patterns if re.search(p, lower))
+        if count > 0:
+            scores[intent] = count
+
+    if not scores:
+        return ("factual_lookup", 0.3)
+
+    best_intent = max(scores, key=lambda k: scores[k])
+    best_score = scores[best_intent]
+
+    # Confidence: base 0.5, boost if only one category matched
+    confidence = min(0.5 + best_score * 0.1, 0.95)
+    if len(scores) == 1:
+        confidence = max(confidence, 0.6)
+
+    return (best_intent, round(confidence, 2))
+
+
+def router_node(state: dict) -> dict:
+    """Route user message to an intent category.
+
+    Args:
+        state: ChatState dict with message.
+
+    Returns:
+        State update with intent and intent_confidence.
     """
-    raise NotImplementedError("Chat pipeline not yet implemented")
+    message = state.get("message", "")
+    intent, confidence = _classify_intent(message)
+    return {"intent": intent, "intent_confidence": confidence}
+
+
+# --- Field search ---
+
+def _search_fields(
+    fields: list[dict], query: str, intent: str
+) -> list[dict]:
+    """Search extracted fields for relevance to the query.
+
+    Scoring:
+    - Exact key match: 1.0
+    - Key term overlap: 0.5 per term
+    - Value term overlap: 0.3 per term
+    - Required field boost for factual_lookup: +0.2
+
+    Args:
+        fields: List of extracted field dicts.
+        query: User's search query.
+        intent: Classified intent type.
+
+    Returns:
+        Sorted list of matching fields, limited by intent.
+    """
+    if not fields or not query.strip():
+        return []
+
+    limit = _INTENT_LIMITS.get(intent, 5)
+    query_terms = set(re.findall(r"\w+", query.lower()))
+
+    scored: list[tuple[float, dict]] = []
+
+    for field in fields:
+        score = 0.0
+        field_key = (field.get("field_key") or "").lower()
+        field_value = (field.get("field_value") or "").lower()
+
+        # Exact key match
+        if field_key and field_key in query.lower():
+            score += 1.0
+
+        # Key term overlap
+        key_terms = set(field_key.replace("_", " ").split())
+        key_overlap = len(query_terms & key_terms)
+        score += key_overlap * 0.5
+
+        # Value term overlap
+        value_terms = set(re.findall(r"\w+", field_value))
+        value_overlap = len(query_terms & value_terms)
+        score += value_overlap * 0.3
+
+        # Required field boost for factual_lookup (only if already relevant)
+        if score > 0 and intent == "factual_lookup" and field.get("is_required"):
+            score += 0.2
+
+        if score > 0:
+            scored.append((score, field))
+
+    scored.sort(key=lambda x: x[0], reverse=True)
+    return [f for _, f in scored[:limit]]
+
+
+def retrieve_node(state: dict) -> dict:
+    """Retrieve relevant fields for the user's query.
+
+    For factual_lookup with low-confidence fields and available page images,
+    marks fields for VLM re-query (limited to 3).
+
+    Args:
+        state: ChatState dict with message, intent, extracted_fields, page_images.
+
+    Returns:
+        State update with relevant_fields and re_queried_regions.
+    """
+    message = state.get("message", "")
+    intent = state.get("intent", "factual_lookup")
+    fields = state.get("extracted_fields", [])
+    page_images = state.get("page_images", [])
+
+    relevant = _search_fields(fields, message, intent)
+
+    re_queried: list[dict] = []
+    if intent == "factual_lookup" and page_images:
+        low_conf = [
+            f for f in relevant
+            if f.get("confidence", 1.0) < _LOW_CONFIDENCE_THRESHOLD
+        ]
+        for f in low_conf[:_MAX_REQUERY_FIELDS]:
+            bbox = f.get("bounding_box", {})
+            if bbox:
+                re_queried.append({
+                    "field_key": f.get("field_key", ""),
+                    "page_number": f.get("page_number", 1),
+                    "bounding_box": bbox,
+                    "original_confidence": f.get("confidence", 0.0),
+                })
+
+    return {
+        "relevant_fields": relevant,
+        "re_queried_regions": re_queried,
+    }
+
+
+# --- Placeholder nodes (implemented in #24) ---
+
+def reason_node(state: dict) -> dict:
+    """Generate answer from relevant fields (placeholder).
+
+    Args:
+        state: ChatState dict.
+
+    Returns:
+        State update with raw_answer and answer.
+    """
+    fields = state.get("relevant_fields", [])
+    message = state.get("message", "")
+
+    if not fields:
+        answer = "I couldn't find relevant information in this document to answer your question."
+    else:
+        field_info = "; ".join(
+            f"{f.get('field_key', '')}: {f.get('field_value', '')}"
+            for f in fields[:5]
+        )
+        answer = f"Based on the document: {field_info}"
+
+    return {"raw_answer": answer, "answer": answer}
+
+
+def cite_node(state: dict) -> dict:
+    """Generate citations from relevant fields (placeholder).
+
+    Args:
+        state: ChatState dict.
+
+    Returns:
+        State update with citations.
+    """
+    fields = state.get("relevant_fields", [])
+    citations: list[Citation] = []
+
+    for f in fields:
+        bbox = f.get("bounding_box", {})
+        if bbox:
+            citations.append(Citation(
+                page=f.get("page_number", 1),
+                bounding_box=bbox,
+                text_span=f"{f.get('field_key', '')}: {f.get('field_value', '')}",
+            ))
+
+    return {"citations": citations}
+
+
+# --- Graph wiring ---
+
+def build_chat_graph():
+    """Build and compile the LangGraph chat pipeline.
+
+    Graph: router -> retrieve -> reason -> cite -> END.
+
+    Returns:
+        Compiled StateGraph ready for invocation.
+    """
+    from langgraph.graph import END, StateGraph
+
+    graph = StateGraph(ChatState)
+    graph.add_node("router", router_node)
+    graph.add_node("retrieve", retrieve_node)
+    graph.add_node("reason", reason_node)
+    graph.add_node("cite", cite_node)
+
+    graph.set_entry_point("router")
+    graph.add_edge("router", "retrieve")
+    graph.add_edge("retrieve", "reason")
+    graph.add_edge("reason", "cite")
+    graph.add_edge("cite", END)
+
+    return graph.compile()
+
+
+chat_graph = build_chat_graph()
+
+
+def run_chat_pipeline(initial_state: dict, config: dict | None = None) -> dict:
+    """Run the full chat pipeline.
+
+    Args:
+        initial_state: ChatState dict with document data and message.
+        config: Optional LangGraph config.
+
+    Returns:
+        Final state dict after all nodes have executed.
+    """
+    return chat_graph.invoke(initial_state, config=config)

--- a/backend/tests/unit/library/pipeline/test_chat_retrieve.py
+++ b/backend/tests/unit/library/pipeline/test_chat_retrieve.py
@@ -1,0 +1,156 @@
+"""Unit tests for chat pipeline retrieve_node and field search."""
+import pytest
+from unittest.mock import MagicMock
+
+
+@pytest.fixture
+def sample_fields():
+    """Sample extracted fields for testing search."""
+    return [
+        {
+            "field_key": "invoice_number",
+            "field_value": "INV-2026-001",
+            "page_number": 1,
+            "confidence": 0.95,
+            "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+            "is_required": True,
+        },
+        {
+            "field_key": "vendor_name",
+            "field_value": "Acme Corporation",
+            "page_number": 1,
+            "confidence": 0.88,
+            "bounding_box": {"x": 0.1, "y": 0.1, "width": 0.4, "height": 0.05},
+            "is_required": True,
+        },
+        {
+            "field_key": "total_amount",
+            "field_value": "$1,500.00",
+            "page_number": 1,
+            "confidence": 0.45,
+            "bounding_box": {"x": 0.5, "y": 0.8, "width": 0.2, "height": 0.05},
+            "is_required": True,
+        },
+        {
+            "field_key": "due_date",
+            "field_value": "2026-03-30",
+            "page_number": 1,
+            "confidence": 0.72,
+            "bounding_box": {"x": 0.5, "y": 0.3, "width": 0.2, "height": 0.05},
+            "is_required": False,
+        },
+    ]
+
+
+class TestSearchFields:
+    """Tests for _search_fields function."""
+
+    def test_exact_key_match_scores_highest(self, sample_fields):
+        from docmind.library.pipeline.chat import _search_fields
+
+        results = _search_fields(sample_fields, "invoice_number", "factual_lookup")
+
+        assert len(results) > 0
+        assert results[0]["field_key"] == "invoice_number"
+
+    def test_term_overlap_finds_related_fields(self, sample_fields):
+        from docmind.library.pipeline.chat import _search_fields
+
+        results = _search_fields(sample_fields, "what is the total amount", "factual_lookup")
+
+        assert len(results) > 0
+        keys = [f["field_key"] for f in results]
+        assert "total_amount" in keys
+
+    def test_factual_lookup_limited_to_5(self, sample_fields):
+        from docmind.library.pipeline.chat import _search_fields
+
+        many_fields = sample_fields * 10
+        results = _search_fields(many_fields, "invoice", "factual_lookup")
+
+        assert len(results) <= 5
+
+    def test_summarization_allows_more_fields(self, sample_fields):
+        from docmind.library.pipeline.chat import _search_fields
+
+        many_fields = sample_fields * 10
+        results = _search_fields(many_fields, "overview of everything", "summarization")
+
+        assert len(results) <= 20
+
+    def test_returns_empty_for_no_match(self, sample_fields):
+        from docmind.library.pipeline.chat import _search_fields
+
+        results = _search_fields(sample_fields, "xyzzyspoon", "factual_lookup")
+
+        assert results == []
+
+    def test_empty_fields_returns_empty(self):
+        from docmind.library.pipeline.chat import _search_fields
+
+        results = _search_fields([], "invoice number", "factual_lookup")
+
+        assert results == []
+
+
+class TestRetrieveNode:
+    """Tests for retrieve_node pipeline function."""
+
+    def test_returns_relevant_fields(self, sample_fields):
+        from docmind.library.pipeline.chat import retrieve_node
+
+        state = {
+            "message": "What is the invoice number?",
+            "intent": "factual_lookup",
+            "extracted_fields": sample_fields,
+            "page_images": [],
+        }
+
+        result = retrieve_node(state)
+
+        assert "relevant_fields" in result
+        assert "re_queried_regions" in result
+        assert len(result["relevant_fields"]) > 0
+
+    def test_no_requery_without_page_images(self, sample_fields):
+        from docmind.library.pipeline.chat import retrieve_node
+
+        state = {
+            "message": "What is the total amount?",
+            "intent": "factual_lookup",
+            "extracted_fields": sample_fields,
+            "page_images": [],
+        }
+
+        result = retrieve_node(state)
+
+        assert result["re_queried_regions"] == []
+
+    def test_no_requery_for_non_factual_intents(self, sample_fields):
+        from docmind.library.pipeline.chat import retrieve_node
+
+        state = {
+            "message": "Summarize the document",
+            "intent": "summarization",
+            "extracted_fields": sample_fields,
+            "page_images": [MagicMock()],
+        }
+
+        result = retrieve_node(state)
+
+        assert result["re_queried_regions"] == []
+
+    def test_handles_empty_extracted_fields(self):
+        from docmind.library.pipeline.chat import retrieve_node
+
+        state = {
+            "message": "What is the total?",
+            "intent": "factual_lookup",
+            "extracted_fields": [],
+            "page_images": [],
+        }
+
+        result = retrieve_node(state)
+
+        assert result["relevant_fields"] == []
+        assert result["re_queried_regions"] == []

--- a/backend/tests/unit/library/pipeline/test_chat_router.py
+++ b/backend/tests/unit/library/pipeline/test_chat_router.py
@@ -1,0 +1,102 @@
+"""Unit tests for chat pipeline router_node and intent classification."""
+import pytest
+
+
+class TestClassifyIntent:
+    """Tests for _classify_intent function."""
+
+    def test_factual_lookup_what_is(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, confidence = _classify_intent("What is the invoice number?")
+        assert intent == "factual_lookup"
+        assert confidence > 0.3
+
+    def test_factual_lookup_how_much(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("How much is the total amount?")
+        assert intent == "factual_lookup"
+
+    def test_reasoning_why(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("Why is the tax amount different from the subtotal?")
+        assert intent == "reasoning"
+
+    def test_reasoning_explain(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("Explain the payment terms")
+        assert intent == "reasoning"
+
+    def test_summarization_summarize(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("Summarize this document")
+        assert intent == "summarization"
+
+    def test_summarization_overview(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("Give me an overview of the contract")
+        assert intent == "summarization"
+
+    def test_comparison_compare(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("Compare the subtotal and total amount")
+        assert intent == "comparison"
+
+    def test_comparison_difference(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("What is the difference between gross and net?")
+        assert intent == "comparison"
+
+    def test_default_intent_for_ambiguous_message(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, confidence = _classify_intent("hello there")
+        assert intent == "factual_lookup"
+        assert confidence == 0.3
+
+    def test_confidence_boost_single_category(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        _, confidence = _classify_intent("Summarize this document please")
+        assert confidence >= 0.5
+
+    def test_case_insensitive(self):
+        from docmind.library.pipeline.chat import _classify_intent
+
+        intent, _ = _classify_intent("WHAT IS THE TOTAL?")
+        assert intent == "factual_lookup"
+
+
+class TestRouterNode:
+    """Tests for router_node pipeline function."""
+
+    def test_returns_intent_and_confidence(self):
+        from docmind.library.pipeline.chat import router_node
+
+        state = {
+            "message": "What is the invoice number?",
+            "document_id": "doc-001",
+            "user_id": "user-001",
+        }
+        result = router_node(state)
+
+        assert "intent" in result
+        assert "intent_confidence" in result
+        assert result["intent"] in ["factual_lookup", "reasoning", "summarization", "comparison"]
+        assert 0.0 <= result["intent_confidence"] <= 1.0
+
+    def test_empty_message_returns_default(self):
+        from docmind.library.pipeline.chat import router_node
+
+        state = {"message": ""}
+        result = router_node(state)
+
+        assert result["intent"] == "factual_lookup"
+        assert result["intent_confidence"] == 0.3


### PR DESCRIPTION
## Summary
- Implement `_classify_intent` with regex pattern matching for 4 intent types
- Implement `_search_fields` with scoring: key match, term overlap, required boost
- Implement `router_node` and `retrieve_node` pipeline nodes
- Build `chat_graph` with LangGraph StateGraph (router -> retrieve -> reason -> cite)
- Placeholder reason/cite nodes for #24

## Test plan
- [x] 13 intent classification tests (all intents, default, boost, case insensitive)
- [x] 10 retrieve/search tests (scoring, limits, empty, re-query logic)
- [x] All 23 chat tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)