### PR TITLE
feat(chat): reason + cite nodes with VLM grounding #24

### DIFF
--- a/backend/src/docmind/library/pipeline/chat.py
+++ b/backend/src/docmind/library/pipeline/chat.py
@@ -6,10 +6,12 @@ LangGraph StateGraph for the document chat agent.
 Nodes: router -> retrieve -> reason -> cite -> END.
 """
 
+import asyncio
 import re
 from typing import Any, Callable, TypedDict
 
 from docmind.core.logging import get_logger
+from docmind.library.providers.factory import get_vlm_provider
 
 logger = get_logger(__name__)
 
@@ -247,54 +249,238 @@ def retrieve_node(state: dict) -> dict:
     }
 
 
-# --- Placeholder nodes (implemented in #24) ---
+# --- Reasoning ---
+
+GROUNDING_SYSTEM_PROMPT = """You are a document analysis assistant. You MUST answer based ONLY on the extracted document data provided below. Do NOT hallucinate or infer information not present in the data. If the data does not contain the answer, say so clearly.
+
+When referencing specific data, mention the page number (e.g., "on page 1")."""
+
+_MAX_PAGE_IMAGES = 4
+_MAX_CONVERSATION_HISTORY = 6
+
+_REASONING_INSTRUCTIONS: dict[str, str] = {
+    "factual_lookup": "Provide a precise, exact answer based on the document data. Quote the relevant values directly.",
+    "reasoning": "Provide a step-by-step explanation based on the document data. Show your reasoning clearly.",
+    "summarization": "Synthesize and summarize the key information from the document data provided.",
+    "comparison": "Compare the relevant values side-by-side, highlighting similarities and differences.",
+}
+
+
+def _confidence_label(confidence: float) -> str:
+    """Map confidence score to human label."""
+    if confidence >= 0.8:
+        return "high"
+    if confidence >= 0.5:
+        return "medium"
+    return "LOW"
+
+
+def _build_context(state: dict) -> str:
+    """Build document context string from state.
+
+    Args:
+        state: ChatState dict with relevant_fields, re_queried_regions,
+               conversation_history.
+
+    Returns:
+        Formatted context string for the VLM prompt.
+    """
+    parts: list[str] = []
+
+    # Relevant fields
+    fields = state.get("relevant_fields", [])
+    if fields:
+        parts.append("EXTRACTED DOCUMENT DATA:")
+        for f in fields:
+            key = f.get("field_key", "unknown")
+            value = f.get("field_value", "")
+            page = f.get("page_number", "?")
+            conf = _confidence_label(f.get("confidence", 0.0))
+            parts.append(f'- [{key}] = "{value}" (page {page}, confidence: {conf})')
+
+    # Re-queried regions
+    regions = state.get("re_queried_regions", [])
+    if regions:
+        parts.append("\nDETAILED RE-ANALYSIS:")
+        for r in regions:
+            key = r.get("field_key", "unknown")
+            detail = r.get("detailed_value", "")
+            page = r.get("page_number", "?")
+            parts.append(f"- [{key}] page {page}: {detail}")
+
+    # Conversation history (capped)
+    history = state.get("conversation_history", [])
+    if history:
+        recent = history[-_MAX_CONVERSATION_HISTORY:]
+        parts.append("\nCONVERSATION HISTORY:")
+        for msg in recent:
+            role = msg.get("role", "user").upper()
+            content = msg.get("content", "")
+            parts.append(f"{role}: {content}")
+
+    return "\n".join(parts)
+
+
+def _get_reasoning_instruction(intent: str) -> str:
+    """Get intent-specific reasoning instruction.
+
+    Args:
+        intent: Classified intent type.
+
+    Returns:
+        Instruction string for the VLM prompt.
+    """
+    return _REASONING_INSTRUCTIONS.get(intent, _REASONING_INSTRUCTIONS["factual_lookup"])
+
 
 def reason_node(state: dict) -> dict:
-    """Generate answer from relevant fields (placeholder).
+    """Generate a grounded answer using the VLM provider.
+
+    Constructs context from relevant fields, calls VLM with grounding
+    system prompt, and streams tokens via callback if provided.
 
     Args:
         state: ChatState dict.
 
     Returns:
-        State update with raw_answer and answer.
+        State update with raw_answer.
     """
-    fields = state.get("relevant_fields", [])
-    message = state.get("message", "")
+    try:
+        context = _build_context(state)
+        instruction = _get_reasoning_instruction(state.get("intent", "factual_lookup"))
+        message = state.get("message", "")
+        page_images = state.get("page_images", [])[:_MAX_PAGE_IMAGES]
+        callback = state.get("stream_callback")
 
-    if not fields:
-        answer = "I couldn't find relevant information in this document to answer your question."
-    else:
-        field_info = "; ".join(
-            f"{f.get('field_key', '')}: {f.get('field_value', '')}"
-            for f in fields[:5]
-        )
-        answer = f"Based on the document: {field_info}"
+        prompt = f"{context}\n\n{instruction}\n\nUser question: {message}"
 
-    return {"raw_answer": answer, "answer": answer}
+        provider = get_vlm_provider()
+
+        loop = asyncio.new_event_loop()
+        try:
+            response = loop.run_until_complete(
+                provider.chat(
+                    prompt=prompt,
+                    system_prompt=GROUNDING_SYSTEM_PROMPT,
+                    images=page_images,
+                )
+            )
+        finally:
+            loop.close()
+
+        answer = response.get("content", "")
+
+        # Stream tokens via callback
+        if callback and answer:
+            callback("token", content=answer)
+
+        return {"raw_answer": answer}
+
+    except Exception as e:
+        logger.error("reason_node_error: %s", e, exc_info=True)
+        return {"raw_answer": "I encountered an error while processing your question. Please try again."}
+
+
+# --- Citation extraction ---
+
+def _extract_page_references(answer: str) -> list[int]:
+    """Extract page number references from answer text.
+
+    Matches patterns like "page 1", "p. 2", "p2".
+
+    Args:
+        answer: The generated answer text.
+
+    Returns:
+        Sorted, deduplicated list of page numbers.
+    """
+    pattern = r'\bpage\s+(\d+)\b|\bp\.?\s*(\d+)\b'
+    matches = re.findall(pattern, answer, re.IGNORECASE)
+    pages: set[int] = set()
+    for groups in matches:
+        for g in groups:
+            if g:
+                pages.add(int(g))
+    return sorted(pages)
+
+
+def _match_citations(
+    answer: str, relevant_fields: list[dict]
+) -> list[Citation]:
+    """Match field values in the answer to generate citations.
+
+    Args:
+        answer: The generated answer text.
+        relevant_fields: Fields from retrieval.
+
+    Returns:
+        Deduplicated list of Citation dicts.
+    """
+    if not answer or not relevant_fields:
+        return []
+
+    citations: list[Citation] = []
+    seen: set[str] = set()
+    answer_lower = answer.lower()
+
+    # Match field values in answer
+    for f in relevant_fields:
+        value = f.get("field_value", "")
+        if len(value) < 2:
+            continue
+
+        if value.lower() in answer_lower:
+            dedup_key = f"{f.get('page_number', 0)}:{value}"
+            if dedup_key not in seen:
+                seen.add(dedup_key)
+                citations.append(Citation(
+                    page=f.get("page_number", 1),
+                    bounding_box=f.get("bounding_box", {}),
+                    text_span=value,
+                ))
+
+    # Match page references to fields
+    page_refs = _extract_page_references(answer)
+    for page in page_refs:
+        for f in relevant_fields:
+            if f.get("page_number") == page:
+                value = f.get("field_value", "")
+                dedup_key = f"{page}:{value}"
+                if dedup_key not in seen:
+                    seen.add(dedup_key)
+                    citations.append(Citation(
+                        page=page,
+                        bounding_box=f.get("bounding_box", {}),
+                        text_span=value,
+                    ))
+
+    return citations
 
 
 def cite_node(state: dict) -> dict:
-    """Generate citations from relevant fields (placeholder).
+    """Extract citations from the answer and relevant fields.
+
+    Matches field values in the answer text, extracts page references,
+    and streams citation events via callback.
 
     Args:
-        state: ChatState dict.
+        state: ChatState dict with raw_answer, relevant_fields.
 
     Returns:
-        State update with citations.
+        State update with answer and citations.
     """
+    answer = state.get("raw_answer", "")
     fields = state.get("relevant_fields", [])
-    citations: list[Citation] = []
+    callback = state.get("stream_callback")
 
-    for f in fields:
-        bbox = f.get("bounding_box", {})
-        if bbox:
-            citations.append(Citation(
-                page=f.get("page_number", 1),
-                bounding_box=bbox,
-                text_span=f"{f.get('field_key', '')}: {f.get('field_value', '')}",
-            ))
+    citations = _match_citations(answer, fields)
 
-    return {"citations": citations}
+    if callback:
+        for c in citations:
+            callback("citation", citation=c)
+        callback("done")
+
+    return {"answer": answer, "citations": citations}
 
 
 # --- Graph wiring ---

--- a/backend/tests/unit/library/pipeline/test_chat_cite.py
+++ b/backend/tests/unit/library/pipeline/test_chat_cite.py
@@ -1,0 +1,205 @@
+"""Unit tests for chat pipeline cite_node and citation extraction."""
+import pytest
+
+
+class TestExtractPageReferences:
+    """Tests for _extract_page_references helper."""
+
+    def test_extracts_page_N_format(self):
+        from docmind.library.pipeline.chat import _extract_page_references
+
+        pages = _extract_page_references("The total on page 1 is $1,500. See page 3 for details.")
+        assert 1 in pages
+        assert 3 in pages
+
+    def test_extracts_p_dot_N_format(self):
+        from docmind.library.pipeline.chat import _extract_page_references
+
+        pages = _extract_page_references("As shown on p. 2, the vendor is Acme.")
+        assert 2 in pages
+
+    def test_returns_empty_for_no_references(self):
+        from docmind.library.pipeline.chat import _extract_page_references
+
+        pages = _extract_page_references("The invoice total is $1,500.")
+        assert pages == []
+
+    def test_deduplicates_page_numbers(self):
+        from docmind.library.pipeline.chat import _extract_page_references
+
+        pages = _extract_page_references("Page 1 shows the header. Also on page 1 is the date.")
+        assert pages == [1]
+
+    def test_returns_sorted_pages(self):
+        from docmind.library.pipeline.chat import _extract_page_references
+
+        pages = _extract_page_references("See page 3, then page 1, then page 2.")
+        assert pages == [1, 2, 3]
+
+
+class TestMatchCitations:
+    """Tests for _match_citations helper."""
+
+    def test_matches_field_values_in_answer(self):
+        from docmind.library.pipeline.chat import _match_citations
+
+        answer = "The invoice number is INV-2026-001 and the vendor is Acme Corp."
+        fields = [
+            {"field_key": "invoice_number", "field_value": "INV-2026-001",
+             "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+             "confidence": 0.95},
+            {"field_key": "vendor_name", "field_value": "Acme Corp",
+             "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.1, "width": 0.4, "height": 0.05},
+             "confidence": 0.90},
+        ]
+
+        citations = _match_citations(answer, fields)
+
+        assert len(citations) == 2
+        text_spans = [c["text_span"] for c in citations]
+        assert "INV-2026-001" in text_spans
+        assert "Acme Corp" in text_spans
+
+    def test_skips_short_field_values(self):
+        from docmind.library.pipeline.chat import _match_citations
+
+        answer = "The value is A."
+        fields = [
+            {"field_key": "code", "field_value": "A",
+             "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.1, "height": 0.05},
+             "confidence": 0.9},
+        ]
+
+        citations = _match_citations(answer, fields)
+        assert len(citations) == 0
+
+    def test_deduplicates_citations(self):
+        from docmind.library.pipeline.chat import _match_citations
+
+        answer = "The vendor Acme Corp is also known as Acme Corp."
+        fields = [
+            {"field_key": "vendor", "field_value": "Acme Corp",
+             "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+             "confidence": 0.9},
+        ]
+
+        citations = _match_citations(answer, fields)
+        assert len(citations) == 1
+
+    def test_case_insensitive_matching(self):
+        from docmind.library.pipeline.chat import _match_citations
+
+        answer = "The vendor is acme corp."
+        fields = [
+            {"field_key": "vendor", "field_value": "Acme Corp",
+             "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+             "confidence": 0.9},
+        ]
+
+        citations = _match_citations(answer, fields)
+        assert len(citations) == 1
+
+    def test_adds_page_reference_citations(self):
+        from docmind.library.pipeline.chat import _match_citations
+
+        answer = "On page 2, the amount is shown."
+        fields = [
+            {"field_key": "amount", "field_value": "$500",
+             "page_number": 2, "bounding_box": {"x": 0.5, "y": 0.8, "width": 0.2, "height": 0.05},
+             "confidence": 0.85},
+        ]
+
+        citations = _match_citations(answer, fields)
+        page_nums = [c["page"] for c in citations]
+        assert 2 in page_nums
+
+    def test_empty_answer_returns_empty(self):
+        from docmind.library.pipeline.chat import _match_citations
+
+        citations = _match_citations("", [])
+        assert citations == []
+
+
+class TestCiteNode:
+    """Tests for cite_node pipeline function."""
+
+    def test_returns_answer_and_citations(self):
+        from docmind.library.pipeline.chat import cite_node
+
+        state = {
+            "raw_answer": "The invoice number is INV-2026-001.",
+            "relevant_fields": [
+                {"field_key": "invoice_number", "field_value": "INV-2026-001",
+                 "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+                 "confidence": 0.95},
+            ],
+            "stream_callback": None,
+        }
+
+        result = cite_node(state)
+
+        assert "answer" in result
+        assert "citations" in result
+        assert result["answer"] == "The invoice number is INV-2026-001."
+        assert len(result["citations"]) > 0
+
+    def test_streams_citations_when_callback(self):
+        from docmind.library.pipeline.chat import cite_node
+
+        streamed = []
+
+        def callback(event_type, **kwargs):
+            streamed.append({"type": event_type, **kwargs})
+
+        state = {
+            "raw_answer": "The vendor is Acme Corp.",
+            "relevant_fields": [
+                {"field_key": "vendor", "field_value": "Acme Corp",
+                 "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+                 "confidence": 0.9},
+            ],
+            "stream_callback": callback,
+        }
+
+        cite_node(state)
+
+        citation_events = [e for e in streamed if e["type"] == "citation"]
+        done_events = [e for e in streamed if e["type"] == "done"]
+
+        assert len(citation_events) >= 1
+        assert len(done_events) == 1
+
+    def test_works_without_callback(self):
+        from docmind.library.pipeline.chat import cite_node
+
+        state = {
+            "raw_answer": "The total is $1,500.",
+            "relevant_fields": [],
+            "stream_callback": None,
+        }
+
+        result = cite_node(state)
+
+        assert result["answer"] == "The total is $1,500."
+        assert result["citations"] == []
+
+    def test_citation_has_correct_structure(self):
+        from docmind.library.pipeline.chat import cite_node
+
+        state = {
+            "raw_answer": "The vendor is Acme Corp on page 1.",
+            "relevant_fields": [
+                {"field_key": "vendor", "field_value": "Acme Corp",
+                 "page_number": 1, "bounding_box": {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05},
+                 "confidence": 0.9},
+            ],
+            "stream_callback": None,
+        }
+
+        result = cite_node(state)
+
+        for citation in result["citations"]:
+            assert "page" in citation
+            assert "bounding_box" in citation
+            assert "text_span" in citation
+            assert isinstance(citation["page"], int)

--- a/backend/tests/unit/library/pipeline/test_chat_reason.py
+++ b/backend/tests/unit/library/pipeline/test_chat_reason.py
@@ -1,0 +1,220 @@
+"""Unit tests for chat pipeline reason_node."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestBuildContext:
+    """Tests for _build_context helper."""
+
+    def test_builds_context_from_relevant_fields(self):
+        from docmind.library.pipeline.chat import _build_context
+
+        state = {
+            "relevant_fields": [
+                {"field_key": "vendor_name", "field_value": "Acme Corp",
+                 "page_number": 1, "confidence": 0.92},
+                {"field_key": "total_amount", "field_value": "$1,500.00",
+                 "page_number": 1, "confidence": 0.45},
+            ],
+            "re_queried_regions": [],
+            "conversation_history": [],
+        }
+
+        context = _build_context(state)
+
+        assert "vendor_name" in context
+        assert "Acme Corp" in context
+        assert "high" in context.lower()
+        assert "low" in context.lower()
+
+    def test_includes_re_queried_regions(self):
+        from docmind.library.pipeline.chat import _build_context
+
+        state = {
+            "relevant_fields": [],
+            "re_queried_regions": [
+                {"field_key": "total", "detailed_value": "The total is $1,500.00",
+                 "page_number": 1},
+            ],
+            "conversation_history": [],
+        }
+
+        context = _build_context(state)
+
+        assert "DETAILED RE-ANALYSIS" in context
+        assert "total" in context.lower()
+
+    def test_includes_conversation_history(self):
+        from docmind.library.pipeline.chat import _build_context
+
+        state = {
+            "relevant_fields": [],
+            "re_queried_regions": [],
+            "conversation_history": [
+                {"role": "user", "content": "What is the total?"},
+                {"role": "assistant", "content": "The total is $1,500."},
+            ],
+        }
+
+        context = _build_context(state)
+
+        assert "CONVERSATION HISTORY" in context
+        assert "USER" in context
+        assert "ASSISTANT" in context
+
+    def test_caps_conversation_history_at_6(self):
+        from docmind.library.pipeline.chat import _build_context
+
+        state = {
+            "relevant_fields": [],
+            "re_queried_regions": [],
+            "conversation_history": [
+                {"role": "user", "content": f"Message {i}"}
+                for i in range(10)
+            ],
+        }
+
+        context = _build_context(state)
+
+        assert "Message 4" in context
+        assert "Message 9" in context
+        assert "Message 0" not in context
+
+
+class TestGetReasoningInstruction:
+    """Tests for _get_reasoning_instruction helper."""
+
+    def test_factual_lookup_instruction(self):
+        from docmind.library.pipeline.chat import _get_reasoning_instruction
+
+        instruction = _get_reasoning_instruction("factual_lookup")
+        assert "precise" in instruction.lower() or "exact" in instruction.lower()
+
+    def test_reasoning_instruction(self):
+        from docmind.library.pipeline.chat import _get_reasoning_instruction
+
+        instruction = _get_reasoning_instruction("reasoning")
+        assert "step" in instruction.lower()
+
+    def test_summarization_instruction(self):
+        from docmind.library.pipeline.chat import _get_reasoning_instruction
+
+        instruction = _get_reasoning_instruction("summarization")
+        assert "summar" in instruction.lower() or "synthe" in instruction.lower()
+
+    def test_comparison_instruction(self):
+        from docmind.library.pipeline.chat import _get_reasoning_instruction
+
+        instruction = _get_reasoning_instruction("comparison")
+        assert "compar" in instruction.lower() or "side" in instruction.lower()
+
+    def test_unknown_intent_returns_factual(self):
+        from docmind.library.pipeline.chat import _get_reasoning_instruction
+
+        instruction = _get_reasoning_instruction("unknown")
+        factual = _get_reasoning_instruction("factual_lookup")
+        assert instruction == factual
+
+
+class TestReasonNode:
+    """Tests for reason_node pipeline function."""
+
+    @patch("docmind.library.pipeline.chat.get_vlm_provider")
+    def test_returns_raw_answer(self, mock_get_provider):
+        from docmind.library.pipeline.chat import reason_node
+
+        mock_provider = MagicMock()
+        mock_provider.chat = AsyncMock(return_value={"content": "The invoice number is INV-2026-001."})
+        mock_get_provider.return_value = mock_provider
+
+        state = {
+            "message": "What is the invoice number?",
+            "intent": "factual_lookup",
+            "page_images": [],
+            "conversation_history": [],
+            "relevant_fields": [
+                {"field_key": "invoice_number", "field_value": "INV-2026-001",
+                 "page_number": 1, "confidence": 0.95},
+            ],
+            "re_queried_regions": [],
+            "stream_callback": None,
+        }
+
+        result = reason_node(state)
+
+        assert "raw_answer" in result
+        assert "INV-2026-001" in result["raw_answer"]
+
+    @patch("docmind.library.pipeline.chat.get_vlm_provider")
+    def test_streams_tokens_when_callback_provided(self, mock_get_provider):
+        from docmind.library.pipeline.chat import reason_node
+
+        mock_provider = MagicMock()
+        mock_provider.chat = AsyncMock(return_value={"content": "The total is $1500"})
+        mock_get_provider.return_value = mock_provider
+
+        streamed_events = []
+
+        def mock_callback(event_type, **kwargs):
+            streamed_events.append({"type": event_type, **kwargs})
+
+        state = {
+            "message": "How much?",
+            "intent": "factual_lookup",
+            "page_images": [],
+            "conversation_history": [],
+            "relevant_fields": [],
+            "re_queried_regions": [],
+            "stream_callback": mock_callback,
+        }
+
+        reason_node(state)
+
+        token_events = [e for e in streamed_events if e["type"] == "token"]
+        assert len(token_events) > 0
+
+    @patch("docmind.library.pipeline.chat.get_vlm_provider")
+    def test_handles_provider_error_gracefully(self, mock_get_provider):
+        from docmind.library.pipeline.chat import reason_node
+
+        mock_provider = MagicMock()
+        mock_provider.chat = AsyncMock(side_effect=Exception("API timeout"))
+        mock_get_provider.return_value = mock_provider
+
+        state = {
+            "message": "What is the total?",
+            "intent": "factual_lookup",
+            "page_images": [],
+            "conversation_history": [],
+            "relevant_fields": [],
+            "re_queried_regions": [],
+            "stream_callback": None,
+        }
+
+        result = reason_node(state)
+
+        assert "raw_answer" in result
+
+    @patch("docmind.library.pipeline.chat.get_vlm_provider")
+    def test_limits_page_images_to_4(self, mock_get_provider):
+        from docmind.library.pipeline.chat import reason_node
+
+        mock_provider = MagicMock()
+        mock_provider.chat = AsyncMock(return_value={"content": "Answer"})
+        mock_get_provider.return_value = mock_provider
+
+        state = {
+            "message": "Summarize",
+            "intent": "summarization",
+            "page_images": [MagicMock() for _ in range(10)],
+            "conversation_history": [],
+            "relevant_fields": [],
+            "re_queried_regions": [],
+            "stream_callback": None,
+        }
+
+        reason_node(state)
+
+        call_kwargs = mock_provider.chat.call_args
+        images_arg = call_kwargs.kwargs.get("images") or call_kwargs[1].get("images", [])
+        assert len(images_arg) <= 4


### PR DESCRIPTION
## Summary
- Implement `reason_node` with VLM grounding system prompt, context building, token streaming
- Implement `cite_node` with field value matching, page reference extraction, deduplication
- Add helpers: `_build_context`, `_get_reasoning_instruction`, `_extract_page_references`, `_match_citations`
- Limits: 4 page images, 6 conversation history, min 2 char for citation matching

## Test plan
- [x] 13 reason tests (context, instructions, VLM call, streaming, errors, image limit)
- [x] 15 cite tests (page refs, field matching, dedup, case insensitive, streaming, structure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)