### PR TITLE
feat(chat): ChatRepository message persistence #25

### DIFF
--- a/backend/src/docmind/modules/chat/repositories.py
+++ b/backend/src/docmind/modules/chat/repositories.py
@@ -1,11 +1,26 @@
-"""docmind/modules/chat/repositories.py — Stub."""
+"""
+docmind/modules/chat/repositories.py
+
+Chat database operations via SQLAlchemy.
+"""
+
+from sqlalchemy import func, select
 
 from docmind.core.logging import get_logger
+from docmind.dbase.psql.core.session import AsyncSessionLocal
+from docmind.dbase.psql.models import (
+    ChatMessage,
+    Citation,
+    ExtractedField,
+    Extraction,
+)
 
 logger = get_logger(__name__)
 
 
 class ChatRepository:
+    """Repository for chat message CRUD operations via SQLAlchemy."""
+
     async def save_message(
         self,
         document_id: str,
@@ -14,15 +29,146 @@ class ChatRepository:
         content: str,
         citations: list[dict] | None = None,
     ) -> str:
-        raise NotImplementedError
+        """Create a chat message with optional citations.
 
-    async def get_history(self, document_id: str, user_id: str, page: int, limit: int):
-        raise NotImplementedError
+        Args:
+            document_id: The document ID.
+            user_id: The user ID.
+            role: Message role ("user" or "assistant").
+            content: Message content text.
+            citations: Optional list of citation dicts.
+
+        Returns:
+            The created message ID string.
+        """
+        async with AsyncSessionLocal() as session:
+            message = ChatMessage(
+                document_id=document_id,
+                user_id=user_id,
+                role=role,
+                content=content,
+            )
+            session.add(message)
+
+            if citations:
+                for c in citations:
+                    citation = Citation(
+                        message_id=message.id,
+                        page=c.get("page", 1),
+                        bounding_box=c.get("bounding_box", {}),
+                        text_span=c.get("text_span", ""),
+                    )
+                    session.add(citation)
+
+            await session.commit()
+            return str(message.id)
+
+    async def get_history(
+        self,
+        document_id: str,
+        user_id: str,
+        page: int,
+        limit: int,
+    ) -> tuple[list[ChatMessage], int]:
+        """Get paginated chat history for a document.
+
+        Args:
+            document_id: The document ID.
+            user_id: The user ID.
+            page: Page number (1-based).
+            limit: Items per page.
+
+        Returns:
+            Tuple of (items, total_count).
+        """
+        offset = (page - 1) * limit
+
+        async with AsyncSessionLocal() as session:
+            count_stmt = (
+                select(func.count())
+                .select_from(ChatMessage)
+                .where(
+                    ChatMessage.document_id == document_id,
+                    ChatMessage.user_id == user_id,
+                )
+            )
+            total = (await session.execute(count_stmt)).scalar() or 0
+
+            stmt = (
+                select(ChatMessage)
+                .where(
+                    ChatMessage.document_id == document_id,
+                    ChatMessage.user_id == user_id,
+                )
+                .order_by(ChatMessage.created_at.asc())
+                .offset(offset)
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            items = list(result.scalars().all())
+
+            return items, total
 
     async def get_recent_messages(
-        self, document_id: str, user_id: str, limit: int = 20
-    ):
-        raise NotImplementedError
+        self,
+        document_id: str,
+        user_id: str,
+        limit: int = 20,
+    ) -> list[ChatMessage]:
+        """Get the most recent messages for conversation context.
 
-    async def get_extracted_fields(self, document_id: str):
-        raise NotImplementedError
+        Args:
+            document_id: The document ID.
+            user_id: The user ID.
+            limit: Maximum number of messages.
+
+        Returns:
+            List of ChatMessage ORM instances, ordered by created_at ASC.
+        """
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(ChatMessage)
+                .where(
+                    ChatMessage.document_id == document_id,
+                    ChatMessage.user_id == user_id,
+                )
+                .order_by(ChatMessage.created_at.desc())
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            messages = list(result.scalars().all())
+            messages.reverse()  # Return in chronological order
+            return messages
+
+    async def get_extracted_fields(
+        self, document_id: str
+    ) -> list[ExtractedField]:
+        """Get extracted fields for the latest extraction of a document.
+
+        Args:
+            document_id: The document ID.
+
+        Returns:
+            List of ExtractedField ORM instances, or empty list.
+        """
+        async with AsyncSessionLocal() as session:
+            # Find latest extraction ID
+            ext_stmt = (
+                select(Extraction.id)
+                .where(Extraction.document_id == document_id)
+                .order_by(Extraction.created_at.desc())
+                .limit(1)
+            )
+            ext_id = (await session.execute(ext_stmt)).scalar_one_or_none()
+
+            if ext_id is None:
+                return []
+
+            # Get fields
+            fields_stmt = (
+                select(ExtractedField)
+                .where(ExtractedField.extraction_id == ext_id)
+                .order_by(ExtractedField.page_number)
+            )
+            result = await session.execute(fields_stmt)
+            return list(result.scalars().all())

--- a/backend/tests/unit/modules/chat/test_chat_repository.py
+++ b/backend/tests/unit/modules/chat/test_chat_repository.py
@@ -1,0 +1,192 @@
+"""Unit tests for ChatRepository with mocked async session."""
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+@pytest.fixture
+def mock_chat_message():
+    msg = MagicMock()
+    msg.id = "msg-001"
+    msg.document_id = "doc-001"
+    msg.user_id = "user-001"
+    msg.role = "user"
+    msg.content = "What is the invoice number?"
+    msg.created_at = datetime(2026, 3, 15, 10, 0, 0, tzinfo=timezone.utc)
+    msg.citations = []
+    return msg
+
+
+@pytest.fixture
+def mock_assistant_message():
+    msg = MagicMock()
+    msg.id = "msg-002"
+    msg.document_id = "doc-001"
+    msg.user_id = "user-001"
+    msg.role = "assistant"
+    msg.content = "The invoice number is INV-2026-001."
+    msg.created_at = datetime(2026, 3, 15, 10, 0, 1, tzinfo=timezone.utc)
+    msg.citations = [MagicMock(page=1, text_span="INV-2026-001")]
+    return msg
+
+
+class TestChatRepositorySaveMessage:
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.repositories.AsyncSessionLocal")
+    async def test_saves_user_message(self, mock_session_factory):
+        from docmind.modules.chat.repositories import ChatRepository
+
+        mock_session = AsyncMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ChatRepository()
+        result = await repo.save_message(
+            document_id="doc-001",
+            user_id="user-001",
+            role="user",
+            content="What is the total?",
+        )
+
+        mock_session.add.assert_called()
+        mock_session.commit.assert_called_once()
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.repositories.AsyncSessionLocal")
+    async def test_saves_message_with_citations(self, mock_session_factory):
+        from docmind.modules.chat.repositories import ChatRepository
+
+        mock_session = AsyncMock()
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        citations = [
+            {"page": 1, "bounding_box": {"x": 0.1}, "text_span": "INV-001"},
+            {"page": 2, "bounding_box": {"x": 0.5}, "text_span": "$1500"},
+        ]
+
+        repo = ChatRepository()
+        result = await repo.save_message(
+            document_id="doc-001",
+            user_id="user-001",
+            role="assistant",
+            content="The invoice is INV-001 with total $1500.",
+            citations=citations,
+        )
+
+        assert mock_session.add.call_count >= 1
+        mock_session.commit.assert_called_once()
+
+
+class TestChatRepositoryGetHistory:
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.repositories.AsyncSessionLocal")
+    async def test_returns_paginated_messages(self, mock_session_factory, mock_chat_message, mock_assistant_message):
+        from docmind.modules.chat.repositories import ChatRepository
+
+        mock_session = AsyncMock()
+        mock_count_result = MagicMock()
+        mock_count_result.scalar.return_value = 2
+
+        mock_items_result = MagicMock()
+        mock_items_result.scalars.return_value.all.return_value = [mock_chat_message, mock_assistant_message]
+
+        mock_session.execute = AsyncMock(side_effect=[mock_count_result, mock_items_result])
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ChatRepository()
+        items, total = await repo.get_history("doc-001", "user-001", page=1, limit=50)
+
+        assert total == 2
+        assert len(items) == 2
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.repositories.AsyncSessionLocal")
+    async def test_returns_empty_for_no_messages(self, mock_session_factory):
+        from docmind.modules.chat.repositories import ChatRepository
+
+        mock_session = AsyncMock()
+        mock_count_result = MagicMock()
+        mock_count_result.scalar.return_value = 0
+        mock_items_result = MagicMock()
+        mock_items_result.scalars.return_value.all.return_value = []
+
+        mock_session.execute = AsyncMock(side_effect=[mock_count_result, mock_items_result])
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ChatRepository()
+        items, total = await repo.get_history("doc-001", "user-001", page=1, limit=50)
+
+        assert total == 0
+        assert items == []
+
+
+class TestChatRepositoryGetRecentMessages:
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.repositories.AsyncSessionLocal")
+    async def test_returns_recent_messages(self, mock_session_factory, mock_chat_message, mock_assistant_message):
+        from docmind.modules.chat.repositories import ChatRepository
+
+        mock_session = AsyncMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [mock_chat_message, mock_assistant_message]
+        mock_session.execute = AsyncMock(return_value=mock_result)
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ChatRepository()
+        messages = await repo.get_recent_messages("doc-001", "user-001", limit=20)
+
+        assert len(messages) == 2
+
+
+class TestChatRepositoryGetExtractedFields:
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.repositories.AsyncSessionLocal")
+    async def test_returns_fields_for_latest_extraction(self, mock_session_factory):
+        from docmind.modules.chat.repositories import ChatRepository
+
+        mock_session = AsyncMock()
+
+        mock_ext_result = MagicMock()
+        mock_ext_result.scalar_one_or_none.return_value = "ext-001"
+
+        mock_field = MagicMock()
+        mock_field.field_key = "invoice_number"
+        mock_fields_result = MagicMock()
+        mock_fields_result.scalars.return_value.all.return_value = [mock_field]
+
+        mock_session.execute = AsyncMock(side_effect=[mock_ext_result, mock_fields_result])
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ChatRepository()
+        fields = await repo.get_extracted_fields("doc-001")
+
+        assert len(fields) == 1
+        assert fields[0].field_key == "invoice_number"
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.repositories.AsyncSessionLocal")
+    async def test_returns_empty_when_no_extraction(self, mock_session_factory):
+        from docmind.modules.chat.repositories import ChatRepository
+
+        mock_session = AsyncMock()
+        mock_ext_result = MagicMock()
+        mock_ext_result.scalar_one_or_none.return_value = None
+
+        mock_session.execute = AsyncMock(return_value=mock_ext_result)
+        mock_session_factory.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session_factory.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        repo = ChatRepository()
+        fields = await repo.get_extracted_fields("doc-001")
+
+        assert fields == []


### PR DESCRIPTION
## Summary
- Implement `ChatRepository` with 4 async methods
- `save_message`: creates ChatMessage + Citation records in single transaction
- `get_history`: paginated, filtered by document_id + user_id
- `get_recent_messages`: capped list for conversation context
- `get_extracted_fields`: finds latest extraction's fields

## Test plan
- [x] 7 repository tests (save, citations, history, empty, recent, fields, no extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)