### PR TITLE
feat(chat): ChatUseCase SSE streaming + history #26

### DIFF
--- a/backend/src/docmind/modules/chat/apiv1/handler.py
+++ b/backend/src/docmind/modules/chat/apiv1/handler.py
@@ -50,6 +50,6 @@ async def get_chat_history(
     current_user: dict = Depends(get_current_user),
 ):
     chat_usecase = ChatUseCase()
-    return chat_usecase.get_history(
+    return await chat_usecase.get_history(
         document_id=document_id, user_id=current_user["id"], page=page, limit=limit
     )

--- a/backend/src/docmind/modules/chat/usecase.py
+++ b/backend/src/docmind/modules/chat/usecase.py
@@ -1,27 +1,191 @@
-"""docmind/modules/chat/usecase.py — Stub."""
+"""
+docmind/modules/chat/usecase.py
 
+Chat use case — orchestrates chat pipeline, message persistence, and SSE streaming.
+"""
+
+import asyncio
 import json
-from typing import AsyncGenerator
+from typing import Any, AsyncGenerator
 
 from docmind.core.logging import get_logger
+from docmind.library.pipeline.chat import run_chat_pipeline
 
-from .schemas import ChatHistoryResponse
+from .repositories import ChatRepository
+from .schemas import (
+    ChatHistoryResponse,
+    ChatMessageResponse,
+    Citation,
+)
 
 logger = get_logger(__name__)
 
+_HEARTBEAT_TIMEOUT = 30.0
+
 
 class ChatUseCase:
+    """Orchestrates chat operations across pipeline, repository, and service."""
+
+    def __init__(self, repo: ChatRepository | None = None) -> None:
+        self.repo = repo or ChatRepository()
+
     def send_message(
         self, document_id: str, user_id: str, message: str
     ) -> AsyncGenerator[str, None]:
         return self._chat_stream(document_id, user_id, message)
 
+    async def _load_context(
+        self, document_id: str, user_id: str
+    ) -> tuple[list[Any], list[dict], list[dict]]:
+        """Load context for the chat pipeline.
+
+        Returns:
+            Tuple of (page_images, extracted_fields, conversation_history).
+        """
+        extracted_fields_orm = await self.repo.get_extracted_fields(document_id)
+        extracted_fields = [
+            {
+                "field_key": f.field_key,
+                "field_value": f.field_value,
+                "page_number": f.page_number,
+                "confidence": f.confidence,
+                "bounding_box": f.bounding_box or {},
+                "is_required": f.is_required,
+            }
+            for f in extracted_fields_orm
+        ]
+
+        recent = await self.repo.get_recent_messages(document_id, user_id, limit=20)
+        conversation_history = [
+            {"role": m.role, "content": m.content}
+            for m in recent
+        ]
+
+        # Page images would be loaded from storage in production
+        page_images: list[Any] = []
+
+        return page_images, extracted_fields, conversation_history
+
     async def _chat_stream(
         self, document_id: str, user_id: str, message: str
     ) -> AsyncGenerator[str, None]:
-        yield f"data: {json.dumps({'type': 'done', 'message_id': 'stub'})}\n\n"
+        def _sse(data: dict) -> str:
+            return f"data: {json.dumps(data)}\n\n"
 
-    def get_history(
+        # Persist user message
+        await self.repo.save_message(document_id, user_id, "user", message)
+
+        # Load context
+        try:
+            page_images, extracted_fields, conversation_history = await self._load_context(
+                document_id, user_id
+            )
+        except Exception as e:
+            logger.error("chat_context_load_failed: %s", e, exc_info=True)
+            yield _sse({"type": "error", "message": "Failed to load document context"})
+            return
+
+        # Set up streaming queue
+        queue: asyncio.Queue[dict | None] = asyncio.Queue()
+
+        def on_event(event_type: str, **kwargs: Any) -> None:
+            queue.put_nowait({"type": event_type, **kwargs})
+
+        initial_state: dict = {
+            "document_id": document_id,
+            "user_id": user_id,
+            "message": message,
+            "page_images": page_images,
+            "extracted_fields": extracted_fields,
+            "conversation_history": conversation_history,
+            "intent": "",
+            "intent_confidence": 0.0,
+            "relevant_fields": [],
+            "re_queried_regions": [],
+            "raw_answer": "",
+            "answer": "",
+            "citations": [],
+            "error_message": None,
+            "stream_callback": on_event,
+        }
+
+        # Run pipeline in background thread
+        pipeline_task = asyncio.create_task(
+            asyncio.to_thread(run_chat_pipeline, initial_state)
+        )
+
+        # Yield SSE events
+        try:
+            while not pipeline_task.done():
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=_HEARTBEAT_TIMEOUT)
+                    if event is None:
+                        break
+                    yield _sse(event)
+                except asyncio.TimeoutError:
+                    yield _sse({"type": "heartbeat"})
+
+            # Drain remaining events
+            while not queue.empty():
+                event = queue.get_nowait()
+                if event is not None:
+                    yield _sse(event)
+
+            # Get pipeline result
+            result = await pipeline_task
+            answer = result.get("answer", "")
+            citations = result.get("citations", [])
+
+            # Persist assistant message
+            msg_id = await self.repo.save_message(
+                document_id, user_id, "assistant", answer, citations=citations
+            )
+
+            yield _sse({"type": "done", "message_id": msg_id})
+
+        except Exception as e:
+            logger.error("chat_stream_error: %s", e, exc_info=True)
+            yield _sse({"type": "error", "message": "Chat processing failed"})
+
+    async def get_history(
         self, document_id: str, user_id: str, page: int, limit: int
     ) -> ChatHistoryResponse:
-        return ChatHistoryResponse(items=[], total=0, page=page, limit=limit)
+        """Get paginated chat history.
+
+        Args:
+            document_id: The document ID.
+            user_id: The user ID.
+            page: Page number (1-based).
+            limit: Items per page.
+
+        Returns:
+            ChatHistoryResponse with mapped messages and citations.
+        """
+        items_orm, total = await self.repo.get_history(
+            document_id, user_id, page, limit
+        )
+
+        items = [
+            ChatMessageResponse(
+                id=str(m.id),
+                role=m.role,
+                content=m.content,
+                citations=[
+                    Citation(
+                        page=c.page,
+                        bounding_box=c.bounding_box or {},
+                        text_span=c.text_span,
+                    )
+                    for c in (m.citations or [])
+                ],
+                created_at=m.created_at,
+            )
+            for m in items_orm
+        ]
+
+        return ChatHistoryResponse(
+            items=items,
+            total=total,
+            page=page,
+            limit=limit,
+        )

--- a/backend/tests/unit/modules/chat/test_chat_usecase.py
+++ b/backend/tests/unit/modules/chat/test_chat_usecase.py
@@ -1,0 +1,154 @@
+"""Unit tests for ChatUseCase."""
+import json
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from docmind.modules.chat.schemas import ChatHistoryResponse
+
+
+@pytest.fixture
+def mock_chat_message_orm():
+    msg = MagicMock()
+    msg.id = "msg-001"
+    msg.role = "user"
+    msg.content = "What is the invoice number?"
+    msg.created_at = datetime(2026, 3, 15, 10, 0, 0, tzinfo=timezone.utc)
+    msg.citations = []
+    return msg
+
+
+@pytest.fixture
+def mock_assistant_orm():
+    msg = MagicMock()
+    msg.id = "msg-002"
+    msg.role = "assistant"
+    msg.content = "The invoice number is INV-001."
+    msg.created_at = datetime(2026, 3, 15, 10, 0, 1, tzinfo=timezone.utc)
+
+    cit = MagicMock()
+    cit.page = 1
+    cit.bounding_box = {"x": 0.1, "y": 0.2, "width": 0.3, "height": 0.05}
+    cit.text_span = "INV-001"
+    msg.citations = [cit]
+    return msg
+
+
+class TestChatUseCaseGetHistory:
+
+    @pytest.mark.asyncio
+    async def test_returns_chat_history_response(self, mock_chat_message_orm, mock_assistant_orm):
+        from docmind.modules.chat.usecase import ChatUseCase
+
+        usecase = ChatUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_history.return_value = (
+            [mock_chat_message_orm, mock_assistant_orm], 2,
+        )
+
+        result = await usecase.get_history("doc-001", "user-001", page=1, limit=50)
+
+        assert isinstance(result, ChatHistoryResponse)
+        assert result.total == 2
+        assert len(result.items) == 2
+        assert result.items[0].role == "user"
+        assert result.items[1].role == "assistant"
+
+    @pytest.mark.asyncio
+    async def test_maps_citations_correctly(self, mock_assistant_orm):
+        from docmind.modules.chat.usecase import ChatUseCase
+
+        usecase = ChatUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_history.return_value = ([mock_assistant_orm], 1)
+
+        result = await usecase.get_history("doc-001", "user-001", page=1, limit=50)
+
+        msg = result.items[0]
+        assert len(msg.citations) == 1
+        assert msg.citations[0].page == 1
+        assert msg.citations[0].text_span == "INV-001"
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_history(self):
+        from docmind.modules.chat.usecase import ChatUseCase
+
+        usecase = ChatUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.get_history.return_value = ([], 0)
+
+        result = await usecase.get_history("doc-001", "user-001", page=1, limit=50)
+
+        assert result.total == 0
+        assert result.items == []
+
+
+class TestChatUseCaseSendMessage:
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.chat.usecase.run_chat_pipeline")
+    async def test_yields_sse_events(self, mock_pipeline):
+        from docmind.modules.chat.usecase import ChatUseCase
+
+        mock_pipeline.return_value = {
+            "answer": "The total is $1,500.",
+            "citations": [
+                {"page": 1, "bounding_box": {"x": 0.5}, "text_span": "$1,500"},
+            ],
+        }
+
+        usecase = ChatUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.save_message.return_value = "msg-new"
+        usecase._load_context = AsyncMock(return_value=([], [], []))
+
+        events = []
+        async for event_str in usecase._chat_stream("doc-001", "user-001", "What is the total?"):
+            events.append(event_str)
+
+        assert len(events) >= 1
+        all_data = []
+        for e in events:
+            if e.startswith("data: "):
+                data = json.loads(e[len("data: "):].strip())
+                all_data.append(data)
+
+        done_events = [d for d in all_data if d.get("type") == "done"]
+        assert len(done_events) >= 1
+
+    @pytest.mark.asyncio
+    async def test_yields_error_on_context_load_failure(self):
+        from docmind.modules.chat.usecase import ChatUseCase
+
+        usecase = ChatUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.save_message.return_value = "msg-new"
+        usecase._load_context = AsyncMock(side_effect=Exception("DB connection lost"))
+
+        events = []
+        async for event_str in usecase._chat_stream("doc-001", "user-001", "Hello"):
+            events.append(event_str)
+
+        all_data = []
+        for e in events:
+            if e.startswith("data: "):
+                data = json.loads(e[len("data: "):].strip())
+                all_data.append(data)
+
+        error_events = [d for d in all_data if d.get("type") == "error"]
+        assert len(error_events) >= 1
+
+    @pytest.mark.asyncio
+    async def test_persists_user_message(self):
+        from docmind.modules.chat.usecase import ChatUseCase
+
+        usecase = ChatUseCase()
+        usecase.repo = AsyncMock()
+        usecase.repo.save_message.return_value = "msg-new"
+        usecase._load_context = AsyncMock(side_effect=Exception("fail"))
+
+        async for _ in usecase._chat_stream("doc-001", "user-001", "Hello"):
+            pass
+
+        usecase.repo.save_message.assert_any_call("doc-001", "user-001", "user", "Hello")


### PR DESCRIPTION
## Summary
- Implement `ChatUseCase` with full SSE streaming for chat pipeline
- `_chat_stream`: user message persistence, context loading, background pipeline, SSE events
- `get_history`: paginated messages with citation mapping
- Fix handler to `await` async `get_history`
- SSE events: token, citation, done, error, heartbeat (30s)

## Test plan
- [x] 3 history tests (response, citations, empty)
- [x] 3 SSE stream tests (events, error on context failure, user message persistence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)