### PR TITLE
feat(frontend): landing page #27

### DIFF
--- a/frontend/src/components/landing/Demo.tsx
+++ b/frontend/src/components/landing/Demo.tsx
@@ -1,3 +1,32 @@
+import { Play } from "lucide-react";
+
 export function Demo() {
-  return <div>Demo</div>;
+  return (
+    <section className="py-24 bg-gray-900/50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            See it in action
+          </h2>
+          <p className="text-lg text-gray-400">
+            Watch how DocMind-VLM processes a real document
+          </p>
+        </div>
+
+        <div className="max-w-4xl mx-auto">
+          <div className="aspect-video bg-gray-900 rounded-xl border border-gray-800 overflow-hidden relative group cursor-pointer hover:border-gray-700 transition-colors">
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="w-20 h-20 bg-blue-600/80 group-hover:bg-blue-500 rounded-full flex items-center justify-center transition-colors shadow-lg shadow-blue-500/20">
+                <Play className="w-8 h-8 text-white ml-1" />
+              </div>
+            </div>
+            <div className="absolute bottom-4 left-4 right-4 flex items-center justify-between text-sm text-gray-500">
+              <span>Demo video coming soon</span>
+              <span>~2 min</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/frontend/src/components/landing/Features.tsx
+++ b/frontend/src/components/landing/Features.tsx
@@ -1,3 +1,79 @@
+import { FileUp, Eye, GitCompare, MessageSquare } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface FeatureItem {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  detail: string;
+}
+
+const features: FeatureItem[] = [
+  {
+    icon: <FileUp className="w-6 h-6" />,
+    title: "Extract",
+    description: "Upload any doc. Get structured data instantly.",
+    detail:
+      "PDFs, images, scanned documents — our VLM extracts key-value pairs, tables, and entities with per-field confidence scores and precise bounding boxes.",
+  },
+  {
+    icon: <Eye className="w-6 h-6" />,
+    title: "Understand",
+    description: "See where the AI is confident — and where it's not.",
+    detail:
+      "Color-coded confidence overlays show exactly which fields the model is sure about. Low-confidence fields get human-readable explanations.",
+  },
+  {
+    icon: <GitCompare className="w-6 h-6" />,
+    title: "Compare",
+    description: "Raw VLM vs enhanced. See the difference.",
+    detail:
+      "Side-by-side comparison of raw VLM output and post-processed results. See which fields were corrected, added, or left unchanged.",
+  },
+  {
+    icon: <MessageSquare className="w-6 h-6" />,
+    title: "Chat",
+    description: "Ask questions. Get answers with source citations.",
+    detail:
+      "Natural language Q&A grounded in the document data. Every answer includes page citations and bounding box references you can verify.",
+  },
+];
+
 export function Features() {
-  return <div>Features</div>;
+  return (
+    <section id="features" className="py-24 bg-gray-950">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            Everything you need to understand documents
+          </h2>
+          <p className="text-lg text-gray-400 max-w-2xl mx-auto">
+            From extraction to conversation, DocMind-VLM handles the full pipeline.
+          </p>
+        </div>
+
+        <div className="grid md:grid-cols-2 gap-8">
+          {features.map((feature) => (
+            <div
+              key={feature.title}
+              className="group bg-gray-900/50 border border-gray-800 rounded-xl p-8 hover:border-blue-500/30 transition-colors"
+            >
+              <div className="w-12 h-12 bg-blue-500/10 rounded-lg flex items-center justify-center text-blue-400 mb-5 group-hover:bg-blue-500/20 transition-colors">
+                {feature.icon}
+              </div>
+              <h3 className="text-xl font-semibold text-white mb-2">
+                {feature.title}
+              </h3>
+              <p className="text-blue-300 font-medium mb-3">
+                {feature.description}
+              </p>
+              <p className="text-gray-400 text-sm leading-relaxed">
+                {feature.detail}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/frontend/src/components/landing/Footer.tsx
+++ b/frontend/src/components/landing/Footer.tsx
@@ -1,3 +1,41 @@
+import { FileText, Github } from "lucide-react";
+
 export function Footer() {
-  return <div>Footer</div>;
+  return (
+    <footer className="py-12 bg-gray-950 border-t border-gray-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col md:flex-row items-center justify-between gap-6">
+          <div className="flex items-center gap-2 text-gray-400">
+            <FileText className="w-5 h-5" />
+            <span className="font-medium text-white">DocMind-VLM</span>
+          </div>
+
+          <div className="flex items-center gap-6 text-sm text-gray-500">
+            <a
+              href="https://github.com/nunenuh/docmind-vlm"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 hover:text-gray-300 transition-colors"
+            >
+              <Github className="w-4 h-4" />
+              GitHub
+            </a>
+            <a
+              href="https://nunenuh.me"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-gray-300 transition-colors"
+            >
+              nunenuh.me
+            </a>
+            <span>MIT License</span>
+          </div>
+
+          <p className="text-sm text-gray-600">
+            &copy; 2026 DocMind-VLM
+          </p>
+        </div>
+      </div>
+    </footer>
+  );
 }

--- a/frontend/src/components/landing/Hero.tsx
+++ b/frontend/src/components/landing/Hero.tsx
@@ -1,3 +1,61 @@
+import { Link } from "react-router-dom";
+import { Sparkles, ArrowRight } from "lucide-react";
+
 export function Hero() {
-  return <div>Hero</div>;
+  return (
+    <section className="relative min-h-screen flex items-center justify-center pt-16 overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-b from-blue-950/30 via-gray-950 to-gray-950" />
+      <div className="absolute top-20 left-1/2 -translate-x-1/2 w-[600px] h-[600px] bg-blue-500/10 rounded-full blur-3xl" />
+
+      <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <div className="inline-flex items-center gap-2 bg-blue-500/10 border border-blue-500/20 rounded-full px-4 py-1.5 mb-8">
+          <Sparkles className="w-4 h-4 text-blue-400" />
+          <span className="text-sm text-blue-300">Powered by Vision Language Models</span>
+        </div>
+
+        <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white leading-tight mb-6">
+          Chat with any document.{" "}
+          <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-cyan-400">
+            See exactly what the AI sees.
+          </span>
+        </h1>
+
+        <p className="text-lg sm:text-xl text-gray-400 max-w-2xl mx-auto mb-10">
+          Upload PDFs or images. Extract structured data with confidence scores
+          and bounding boxes. Ask questions and get answers with source citations.
+        </p>
+
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+          <Link
+            to="/dashboard"
+            className="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-500 text-white font-medium px-8 py-3 rounded-lg transition-colors text-lg"
+          >
+            Get Started
+            <ArrowRight className="w-5 h-5" />
+          </Link>
+          <a
+            href="https://github.com/nunenuh/docmind-vlm"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-full sm:w-auto inline-flex items-center justify-center gap-2 border border-gray-700 hover:border-gray-500 text-gray-300 hover:text-white font-medium px-8 py-3 rounded-lg transition-colors text-lg"
+          >
+            View on GitHub
+          </a>
+        </div>
+
+        <div className="mt-16 relative">
+          <div className="aspect-video max-w-4xl mx-auto bg-gray-900 rounded-xl border border-gray-800 overflow-hidden shadow-2xl shadow-blue-500/5">
+            <div className="w-full h-full flex items-center justify-center text-gray-600">
+              <div className="text-center">
+                <div className="w-16 h-16 mx-auto mb-4 rounded-lg bg-gray-800 flex items-center justify-center">
+                  <Sparkles className="w-8 h-8 text-blue-500/50" />
+                </div>
+                <p className="text-sm">Interactive demo preview</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/frontend/src/components/landing/HowItWorks.tsx
+++ b/frontend/src/components/landing/HowItWorks.tsx
@@ -1,0 +1,65 @@
+import { Upload, Cpu, CheckCircle, MessageCircle, ArrowRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface Step {
+  icon: ReactNode;
+  title: string;
+  description: string;
+}
+
+const steps: Step[] = [
+  {
+    icon: <Upload className="w-7 h-7" />,
+    title: "Upload",
+    description: "Drop any PDF or image document",
+  },
+  {
+    icon: <Cpu className="w-7 h-7" />,
+    title: "Extract",
+    description: "VLM extracts structured fields",
+  },
+  {
+    icon: <CheckCircle className="w-7 h-7" />,
+    title: "Verify",
+    description: "Review confidence scores and overlays",
+  },
+  {
+    icon: <MessageCircle className="w-7 h-7" />,
+    title: "Chat",
+    description: "Ask questions with cited answers",
+  },
+];
+
+export function HowItWorks() {
+  return (
+    <section className="py-24 bg-gray-900/50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-16">
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            How it works
+          </h2>
+          <p className="text-lg text-gray-400">
+            Four steps from document to insights
+          </p>
+        </div>
+
+        <div className="flex flex-col md:flex-row items-start md:items-center justify-center gap-4 md:gap-0">
+          {steps.map((step, i) => (
+            <div key={step.title} className="flex items-center">
+              <div className="flex flex-col items-center text-center w-48">
+                <div className="w-16 h-16 bg-blue-500/10 border border-blue-500/20 rounded-2xl flex items-center justify-center text-blue-400 mb-4">
+                  {step.icon}
+                </div>
+                <h3 className="text-white font-semibold mb-1">{step.title}</h3>
+                <p className="text-gray-400 text-sm">{step.description}</p>
+              </div>
+              {i < steps.length - 1 && (
+                <ArrowRight className="hidden md:block w-5 h-5 text-gray-600 mx-4 flex-shrink-0" />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/landing/Navbar.tsx
+++ b/frontend/src/components/landing/Navbar.tsx
@@ -1,0 +1,32 @@
+import { FileText, Github } from "lucide-react";
+import { Link } from "react-router-dom";
+
+export function Navbar() {
+  return (
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-gray-950/80 backdrop-blur-md border-b border-gray-800">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 h-16 flex items-center justify-between">
+        <Link to="/" className="flex items-center gap-2 text-white font-bold text-lg">
+          <FileText className="w-6 h-6 text-blue-400" />
+          DocMind-VLM
+        </Link>
+        <div className="flex items-center gap-4">
+          <a
+            href="https://github.com/nunenuh/docmind-vlm"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-gray-400 hover:text-white transition-colors"
+            aria-label="GitHub repository"
+          >
+            <Github className="w-5 h-5" />
+          </a>
+          <Link
+            to="/dashboard"
+            className="bg-blue-600 hover:bg-blue-500 text-white text-sm font-medium px-4 py-2 rounded-lg transition-colors"
+          >
+            Try it Free
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/frontend/src/components/landing/TechStack.tsx
+++ b/frontend/src/components/landing/TechStack.tsx
@@ -1,0 +1,41 @@
+const techItems = [
+  { name: "Qwen3-VL", category: "VLM" },
+  { name: "LangGraph", category: "Pipeline" },
+  { name: "FastAPI", category: "Backend" },
+  { name: "React", category: "Frontend" },
+  { name: "Supabase", category: "Database" },
+  { name: "OpenCV", category: "CV" },
+  { name: "TypeScript", category: "Language" },
+  { name: "Tailwind", category: "Styling" },
+];
+
+export function TechStack() {
+  return (
+    <section className="py-24 bg-gray-950">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="text-center mb-12">
+          <h2 className="text-3xl sm:text-4xl font-bold text-white mb-4">
+            Built with modern tools
+          </h2>
+          <p className="text-lg text-gray-400">
+            Production-grade stack from extraction to UI
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-4">
+          {techItems.map((item) => (
+            <div
+              key={item.name}
+              className="bg-gray-900/50 border border-gray-800 rounded-lg px-5 py-3 flex items-center gap-3 hover:border-gray-700 transition-colors"
+            >
+              <span className="text-white font-medium">{item.name}</span>
+              <span className="text-xs text-gray-500 bg-gray-800 rounded px-2 py-0.5">
+                {item.category}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,3 +1,21 @@
+import { Navbar } from "@/components/landing/Navbar";
+import { Hero } from "@/components/landing/Hero";
+import { Features } from "@/components/landing/Features";
+import { HowItWorks } from "@/components/landing/HowItWorks";
+import { Demo } from "@/components/landing/Demo";
+import { TechStack } from "@/components/landing/TechStack";
+import { Footer } from "@/components/landing/Footer";
+
 export function LandingPage() {
-  return <div className="min-h-screen flex items-center justify-center"><h1 className="text-2xl font-bold">DocMind-VLM</h1></div>;
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <Navbar />
+      <Hero />
+      <Features />
+      <HowItWorks />
+      <Demo />
+      <TechStack />
+      <Footer />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Implement full landing page with 7 sections
- Navbar: fixed top, logo, GitHub link, CTA button
- Hero: headline, subheadline, dual CTAs, demo preview placeholder
- Features: 4 cards (Extract, Understand, Compare, Chat)
- HowItWorks: 4-step horizontal flow with icons
- Demo: video placeholder with play button
- TechStack: badge grid (Qwen3-VL, LangGraph, FastAPI, React, etc.)
- Footer: GitHub, author, MIT license
- All responsive (mobile/tablet/desktop), dark mode

## Test plan
- [x] TypeScript build passes
- [x] All sections render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)