### PR TITLE
ci: skip integration tests in CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -74,7 +74,7 @@ jobs:
       - run: poetry run pytest tests/unit/ -v --tb=short
 
       - name: Tests with coverage
-        run: poetry run pytest tests/ --cov=docmind --cov-report=term-missing --cov-report=xml:coverage.xml
+        run: poetry run pytest tests/unit/ tests/e2e/ --cov=docmind --cov-report=term-missing --cov-report=xml:coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
Integration tests require Postgres; CI only runs unit + e2e tests