### PR TITLE
ci: unit tests only in CI

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -74,7 +74,7 @@ jobs:
       - run: poetry run pytest tests/unit/ -v --tb=short
 
       - name: Tests with coverage
-        run: poetry run pytest tests/unit/ tests/e2e/ --cov=docmind --cov-report=term-missing --cov-report=xml:coverage.xml
+        run: poetry run pytest tests/unit/ --cov=docmind --cov-report=term-missing --cov-report=xml:coverage.xml
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
E2E tests need real DB/services, run only unit tests in CI