### PR TITLE
feat: API Keys settings + API Reference + rate limiting #94

### DIFF
--- a/backend/src/docmind/core/auth.py
+++ b/backend/src/docmind/core/auth.py
@@ -146,9 +146,19 @@ async def get_current_user(request: Request) -> dict:
 
     # API token path
     if _is_api_token(token):
+        from docmind.core.rate_limit import get_token_rate_limiter
+
+        prefix = token[:12]
+        limiter = get_token_rate_limiter()
+        if limiter.is_blocked(prefix):
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Too many failed attempts. Try again later.",
+            )
         try:
             service = ApiTokenService()
             user_data = await service.validate_token(token)
+            limiter.reset(prefix)
             return {
                 "id": user_data["user_id"],
                 "email": "",
@@ -157,6 +167,7 @@ async def get_current_user(request: Request) -> dict:
                 "token_id": user_data["token_id"],
             }
         except AuthenticationException:
+            limiter.record_failure(prefix)
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Invalid or expired API token",

--- a/backend/src/docmind/core/rate_limit.py
+++ b/backend/src/docmind/core/rate_limit.py
@@ -1,0 +1,55 @@
+"""
+docmind/core/rate_limit.py
+
+Simple in-memory rate limiter for token validation failures.
+Prevents brute-force token guessing by tracking failed attempts per key.
+"""
+
+import time
+import threading
+from collections import defaultdict
+
+from docmind.core.config import get_settings
+
+
+class TokenRateLimiter:
+    """In-memory sliding-window rate limiter for token validation failures."""
+
+    def __init__(self, max_failures: int = 10, window_seconds: int = 300) -> None:
+        self._max_failures = max_failures
+        self._window = window_seconds
+        self._failures: dict[str, list[float]] = defaultdict(list)
+        self._lock = threading.Lock()
+
+    def record_failure(self, key: str) -> None:
+        """Record a failed validation attempt."""
+        now = time.monotonic()
+        with self._lock:
+            self._failures[key].append(now)
+
+    def is_blocked(self, key: str) -> bool:
+        """Check if key has exceeded failure threshold in the current window."""
+        now = time.monotonic()
+        cutoff = now - self._window
+        with self._lock:
+            attempts = self._failures.get(key, [])
+            recent = [t for t in attempts if t > cutoff]
+            self._failures[key] = recent
+            return len(recent) >= self._max_failures
+
+    def reset(self, key: str) -> None:
+        """Clear failures for a key (e.g. after successful validation)."""
+        with self._lock:
+            self._failures.pop(key, None)
+
+
+# Module-level singleton
+_limiter: TokenRateLimiter | None = None
+
+
+def get_token_rate_limiter() -> TokenRateLimiter:
+    """Get or create the global rate limiter instance."""
+    global _limiter
+    if _limiter is None:
+        _limiter = TokenRateLimiter()
+    return _limiter

--- a/backend/src/docmind/core/scopes.py
+++ b/backend/src/docmind/core/scopes.py
@@ -27,7 +27,8 @@ def _check_scopes(current_user: dict, required_scopes: list[str]) -> dict:
     for scope in required_scopes:
         if scope not in user_scopes:
             raise AuthorizationException(
-                f"Missing required scope: {scope}"
+                f"Missing required scope: {scope}",
+                detail={"missing_scope": scope},
             )
 
     return current_user

--- a/backend/src/docmind/main.py
+++ b/backend/src/docmind/main.py
@@ -70,9 +70,12 @@ def create_app() -> FastAPI:
     async def app_exception_handler(request: Request, exc: BaseAppException):
         """Catch any custom exception not handled by the endpoint."""
         logger.error("%s [%s]: %s", exc.__class__.__name__, exc.code, exc.message)
+        body: dict = {"detail": exc.message}
+        if hasattr(exc, "detail") and exc.detail:
+            body.update(exc.detail)
         return JSONResponse(
             status_code=exc.status_code,
-            content={"detail": exc.message},
+            content=body,
         )
 
     @application.exception_handler(Exception)

--- a/backend/src/docmind/shared/exceptions.py
+++ b/backend/src/docmind/shared/exceptions.py
@@ -56,8 +56,9 @@ class ValidationException(UseCaseException):
 class AuthorizationException(UseCaseException):
     """User not authorized for this action."""
 
-    def __init__(self, message: str = "Not authorized") -> None:
+    def __init__(self, message: str = "Not authorized", detail: dict | None = None) -> None:
         super().__init__(message, code="FORBIDDEN", status_code=403)
+        self.detail = detail or {}
 
 
 class AuthenticationException(UseCaseException):

--- a/backend/tests/unit/core/test_rate_limit.py
+++ b/backend/tests/unit/core/test_rate_limit.py
@@ -1,0 +1,47 @@
+"""Unit tests for the token rate limiter."""
+
+import time
+from unittest.mock import patch
+
+from docmind.core.rate_limit import TokenRateLimiter
+
+
+class TestTokenRateLimiter:
+    def test_allows_under_threshold(self):
+        limiter = TokenRateLimiter(max_failures=5, window_seconds=60)
+        for _ in range(4):
+            limiter.record_failure("key1")
+        assert limiter.is_blocked("key1") is False
+
+    def test_blocks_at_threshold(self):
+        limiter = TokenRateLimiter(max_failures=5, window_seconds=60)
+        for _ in range(5):
+            limiter.record_failure("key1")
+        assert limiter.is_blocked("key1") is True
+
+    def test_different_keys_tracked_independently(self):
+        limiter = TokenRateLimiter(max_failures=3, window_seconds=60)
+        for _ in range(3):
+            limiter.record_failure("key_a")
+        assert limiter.is_blocked("key_a") is True
+        assert limiter.is_blocked("key_b") is False
+
+    def test_resets_after_window_expires(self):
+        limiter = TokenRateLimiter(max_failures=3, window_seconds=1)
+        for _ in range(3):
+            limiter.record_failure("key1")
+        assert limiter.is_blocked("key1") is True
+        time.sleep(1.1)
+        assert limiter.is_blocked("key1") is False
+
+    def test_reset_clears_failures(self):
+        limiter = TokenRateLimiter(max_failures=3, window_seconds=60)
+        for _ in range(3):
+            limiter.record_failure("key1")
+        assert limiter.is_blocked("key1") is True
+        limiter.reset("key1")
+        assert limiter.is_blocked("key1") is False
+
+    def test_new_key_is_not_blocked(self):
+        limiter = TokenRateLimiter(max_failures=5, window_seconds=60)
+        assert limiter.is_blocked("never_seen") is False

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -19,6 +19,11 @@ import { Settings } from "@/pages/Settings";
 import { TemplatesPage } from "@/pages/TemplatesPage";
 import { PersonasPage } from "@/pages/PersonasPage";
 import { AnalyticsPage } from "@/pages/AnalyticsPage";
+import { ApiKeysSettings } from "@/pages/ApiKeysSettings";
+import { ApiReference } from "@/pages/ApiReference";
+import { ProfileSettings } from "@/pages/ProfileSettings";
+import { PreferencesSettings } from "@/pages/PreferencesSettings";
+import { AboutSettings } from "@/pages/AboutSettings";
 
 function AuthProvider({ children }: { children: React.ReactNode }) {
   const { setAuth, clearAuth, setIsLoading } = useAuthStore();
@@ -56,7 +61,13 @@ export function App() {
                   <Route path="/projects" element={<ProjectDashboard />} />
                   <Route path="/projects/:projectId" element={<ProjectWorkspace />} />
                   <Route path="/workspace/:documentId" element={<Workspace />} />
-                  <Route path="/settings" element={<Settings />} />
+                  <Route path="/settings" element={<Settings />}>
+                    <Route path="api-keys" element={<ApiKeysSettings />} />
+                    <Route path="api-reference" element={<ApiReference />} />
+                    <Route path="profile" element={<ProfileSettings />} />
+                    <Route path="preferences" element={<PreferencesSettings />} />
+                    <Route path="about" element={<AboutSettings />} />
+                  </Route>
                 </Route>
               </Route>
             </Routes>

--- a/frontend/src/components/settings/CodeExamples.tsx
+++ b/frontend/src/components/settings/CodeExamples.tsx
@@ -1,0 +1,156 @@
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+
+type Language = "curl" | "python" | "javascript";
+
+const TABS: { id: Language; label: string }[] = [
+  { id: "curl", label: "cURL" },
+  { id: "python", label: "Python" },
+  { id: "javascript", label: "JavaScript" },
+];
+
+const EXAMPLES: Record<Language, string> = {
+  curl: `# List all documents
+curl -H "Authorization: Bearer dm_live_xxxxxxxxxxxx" \\
+  https://your-domain.com/api/v1/documents
+
+# Upload a document
+curl -X POST \\
+  -H "Authorization: Bearer dm_live_xxxxxxxxxxxx" \\
+  -F "file=@invoice.pdf" \\
+  https://your-domain.com/api/v1/documents
+
+# Get extraction results
+curl -H "Authorization: Bearer dm_live_xxxxxxxxxxxx" \\
+  https://your-domain.com/api/v1/extractions/{document_id}
+
+# Search the RAG index
+curl -X POST \\
+  -H "Authorization: Bearer dm_live_xxxxxxxxxxxx" \\
+  -H "Content-Type: application/json" \\
+  -d '{"query": "invoice total amount"}' \\
+  https://your-domain.com/api/v1/rag/search`,
+
+  python: `import requests
+
+API_KEY = "dm_live_xxxxxxxxxxxx"
+BASE_URL = "https://your-domain.com/api/v1"
+headers = {"Authorization": f"Bearer {API_KEY}"}
+
+# List all documents
+response = requests.get(f"{BASE_URL}/documents", headers=headers)
+documents = response.json()
+
+# Upload a document
+with open("invoice.pdf", "rb") as f:
+    response = requests.post(
+        f"{BASE_URL}/documents",
+        headers=headers,
+        files={"file": f},
+    )
+    document = response.json()
+
+# Get extraction results
+doc_id = document["id"]
+response = requests.get(
+    f"{BASE_URL}/extractions/{doc_id}",
+    headers=headers,
+)
+extraction = response.json()
+
+# Search the RAG index
+response = requests.post(
+    f"{BASE_URL}/rag/search",
+    headers=headers,
+    json={"query": "invoice total amount"},
+)
+results = response.json()`,
+
+  javascript: `const API_KEY = "dm_live_xxxxxxxxxxxx";
+const BASE_URL = "https://your-domain.com/api/v1";
+const headers = { Authorization: \`Bearer \${API_KEY}\` };
+
+// List all documents
+const docsRes = await fetch(\`\${BASE_URL}/documents\`, { headers });
+const documents = await docsRes.json();
+
+// Upload a document
+const formData = new FormData();
+formData.append("file", fileInput.files[0]);
+const uploadRes = await fetch(\`\${BASE_URL}/documents\`, {
+  method: "POST",
+  headers: { Authorization: \`Bearer \${API_KEY}\` },
+  body: formData,
+});
+const document = await uploadRes.json();
+
+// Get extraction results
+const extRes = await fetch(
+  \`\${BASE_URL}/extractions/\${document.id}\`,
+  { headers },
+);
+const extraction = await extRes.json();
+
+// Search the RAG index
+const ragRes = await fetch(\`\${BASE_URL}/rag/search\`, {
+  method: "POST",
+  headers: { ...headers, "Content-Type": "application/json" },
+  body: JSON.stringify({ query: "invoice total amount" }),
+});
+const results = await ragRes.json();`,
+};
+
+export function CodeExamples() {
+  const [activeTab, setActiveTab] = useState<Language>("curl");
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(EXAMPLES[activeTab]);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex gap-1 bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg p-1">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => {
+                setActiveTab(tab.id);
+                setCopied(false);
+              }}
+              className={`px-3 py-1.5 text-xs font-medium rounded-md transition-colors ${
+                activeTab === tab.id
+                  ? "bg-indigo-600/10 text-indigo-400"
+                  : "text-gray-500 hover:text-gray-300"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs text-gray-500 hover:text-gray-300 border border-[#1e1e2e] hover:border-gray-700 rounded-lg transition-colors"
+        >
+          {copied ? (
+            <>
+              <Check className="w-3.5 h-3.5 text-emerald-400" />
+              <span className="text-emerald-400">Copied!</span>
+            </>
+          ) : (
+            <>
+              <Copy className="w-3.5 h-3.5" />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+      <pre className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-4 py-4 text-xs text-gray-300 font-mono overflow-x-auto whitespace-pre leading-relaxed">
+        {EXAMPLES[activeTab]}
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/CreateTokenModal.tsx
+++ b/frontend/src/components/settings/CreateTokenModal.tsx
@@ -1,0 +1,168 @@
+import { useState } from "react";
+import { X, Loader2 } from "lucide-react";
+import { useCreateToken } from "@/hooks/useApiTokens";
+import { ScopeCheckboxGrid } from "./ScopeCheckboxGrid";
+import type { TokenCreatedResponse } from "@/types/api-token";
+
+interface CreateTokenModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreated: (response: TokenCreatedResponse) => void;
+}
+
+const EXPIRY_OPTIONS = [
+  { label: "7 days", value: 7 },
+  { label: "30 days", value: 30 },
+  { label: "60 days", value: 60 },
+  { label: "90 days", value: 90 },
+  { label: "1 year", value: 365 },
+  { label: "Never", value: null },
+] as const;
+
+export function CreateTokenModal({ isOpen, onClose, onCreated }: CreateTokenModalProps) {
+  const [name, setName] = useState("");
+  const [tokenType, setTokenType] = useState<"live" | "test">("live");
+  const [scopes, setScopes] = useState<string[]>([]);
+  const [expiresInDays, setExpiresInDays] = useState<number | null>(90);
+
+  const createToken = useCreateToken();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || scopes.length === 0) return;
+
+    try {
+      const response = await createToken.mutateAsync({
+        name: name.trim(),
+        scopes: scopes as never[],
+        token_type: tokenType,
+        expires_in_days: expiresInDays,
+      });
+      onCreated(response);
+      setName("");
+      setScopes([]);
+      setTokenType("live");
+      setExpiresInDays(90);
+    } catch {
+      // Error handled by the hook
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative bg-[#12121a] border border-[#1e1e2e] rounded-xl w-full max-w-xl max-h-[85vh] overflow-y-auto shadow-2xl mx-4">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[#1e1e2e] sticky top-0 bg-[#12121a] z-10">
+          <h2 className="text-lg font-semibold text-white">Create API Key</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-5">
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Key Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Production Backend, CI/CD Pipeline"
+              className="w-full bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500 transition-colors"
+              required
+            />
+          </div>
+
+          {/* Token Type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Environment
+            </label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setTokenType("live")}
+                className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg border transition-colors ${
+                  tokenType === "live"
+                    ? "bg-indigo-600/10 border-indigo-500 text-indigo-400"
+                    : "bg-[#0a0a0f] border-[#1e1e2e] text-gray-400 hover:border-gray-700"
+                }`}
+              >
+                Live
+              </button>
+              <button
+                type="button"
+                onClick={() => setTokenType("test")}
+                className={`flex-1 px-4 py-2.5 text-sm font-medium rounded-lg border transition-colors ${
+                  tokenType === "test"
+                    ? "bg-amber-600/10 border-amber-500 text-amber-400"
+                    : "bg-[#0a0a0f] border-[#1e1e2e] text-gray-400 hover:border-gray-700"
+                }`}
+              >
+                Test
+              </button>
+            </div>
+          </div>
+
+          {/* Expiry */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Expiration
+            </label>
+            <select
+              value={expiresInDays ?? "never"}
+              onChange={(e) =>
+                setExpiresInDays(
+                  e.target.value === "never" ? null : Number(e.target.value)
+                )
+              }
+              className="w-full bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white focus:outline-none focus:border-indigo-500 transition-colors"
+            >
+              {EXPIRY_OPTIONS.map((opt) => (
+                <option key={opt.label} value={opt.value ?? "never"}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Scopes */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Permissions
+            </label>
+            <ScopeCheckboxGrid selectedScopes={scopes} onChange={setScopes} />
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-400 hover:text-white border border-[#1e1e2e] hover:border-gray-700 rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!name.trim() || scopes.length === 0 || createToken.isPending}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+            >
+              {createToken.isPending && (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              )}
+              Create Key
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/EditTokenModal.tsx
+++ b/frontend/src/components/settings/EditTokenModal.tsx
@@ -1,0 +1,117 @@
+import { useState, useEffect } from "react";
+import { X, Loader2 } from "lucide-react";
+import { useUpdateToken } from "@/hooks/useApiTokens";
+import { ScopeCheckboxGrid } from "./ScopeCheckboxGrid";
+import type { TokenResponse } from "@/types/api-token";
+
+interface EditTokenModalProps {
+  isOpen: boolean;
+  token: TokenResponse | null;
+  onClose: () => void;
+}
+
+export function EditTokenModal({ isOpen, token, onClose }: EditTokenModalProps) {
+  const [name, setName] = useState("");
+  const [scopes, setScopes] = useState<string[]>([]);
+
+  const updateToken = useUpdateToken();
+
+  useEffect(() => {
+    if (token) {
+      setName(token.name);
+      setScopes([...token.scopes]);
+    }
+  }, [token]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token || !name.trim() || scopes.length === 0) return;
+
+    try {
+      await updateToken.mutateAsync({
+        id: token.id,
+        data: {
+          name: name.trim(),
+          scopes: scopes as never[],
+        },
+      });
+      onClose();
+    } catch {
+      // Error handled by the hook
+    }
+  };
+
+  if (!isOpen || !token) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative bg-[#12121a] border border-[#1e1e2e] rounded-xl w-full max-w-xl max-h-[85vh] overflow-y-auto shadow-2xl mx-4">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-[#1e1e2e] sticky top-0 bg-[#12121a] z-10">
+          <h2 className="text-lg font-semibold text-white">Edit API Key</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-300 transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-5 space-y-5">
+          {/* Prefix (read-only) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Key Prefix
+            </label>
+            <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-gray-500 font-mono">
+              {token.prefix}...
+            </div>
+          </div>
+
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Key Name
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="w-full bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white focus:outline-none focus:border-indigo-500 transition-colors"
+              required
+            />
+          </div>
+
+          {/* Scopes */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Permissions
+            </label>
+            <ScopeCheckboxGrid selectedScopes={scopes} onChange={setScopes} />
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-400 hover:text-white border border-[#1e1e2e] hover:border-gray-700 rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!name.trim() || scopes.length === 0 || updateToken.isPending}
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg transition-colors"
+            >
+              {updateToken.isPending && (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              )}
+              Save Changes
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/EndpointTable.tsx
+++ b/frontend/src/components/settings/EndpointTable.tsx
@@ -1,0 +1,83 @@
+import { ENDPOINT_DEFINITIONS, ENDPOINT_MODULES } from "@/data/endpoints";
+
+const METHOD_STYLES: Record<string, string> = {
+  GET: "bg-emerald-500/10 text-emerald-400 border-emerald-500/20",
+  POST: "bg-blue-500/10 text-blue-400 border-blue-500/20",
+  PUT: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+  PATCH: "bg-amber-500/10 text-amber-400 border-amber-500/20",
+  DELETE: "bg-red-500/10 text-red-400 border-red-500/20",
+};
+
+function MethodBadge({ method }: { method: string }) {
+  const style = METHOD_STYLES[method] ?? "bg-gray-500/10 text-gray-400 border-gray-500/20";
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs font-mono font-medium rounded border ${style}`}
+    >
+      {method}
+    </span>
+  );
+}
+
+export function EndpointTable() {
+  return (
+    <div className="space-y-6">
+      {ENDPOINT_MODULES.map((mod) => {
+        const endpoints = ENDPOINT_DEFINITIONS.filter((e) => e.module === mod);
+        if (endpoints.length === 0) return null;
+        return (
+          <div key={mod}>
+            <h3 className="text-sm font-semibold text-white mb-3">{mod}</h3>
+            <div className="overflow-x-auto bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[#1e1e2e]">
+                    <th className="text-left py-2.5 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider w-20">
+                      Method
+                    </th>
+                    <th className="text-left py-2.5 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Path
+                    </th>
+                    <th className="text-left py-2.5 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider w-40">
+                      Scope
+                    </th>
+                    <th className="text-left py-2.5 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                      Description
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {endpoints.map((ep, idx) => (
+                    <tr
+                      key={`${ep.method}-${ep.path}`}
+                      className={
+                        idx < endpoints.length - 1
+                          ? "border-b border-[#1e1e2e]/50"
+                          : ""
+                      }
+                    >
+                      <td className="py-2 px-4">
+                        <MethodBadge method={ep.method} />
+                      </td>
+                      <td className="py-2 px-4">
+                        <code className="text-xs font-mono text-gray-300">
+                          {ep.path}
+                        </code>
+                      </td>
+                      <td className="py-2 px-4">
+                        <span className="text-xs text-indigo-400">{ep.scope}</span>
+                      </td>
+                      <td className="py-2 px-4 text-gray-400 text-xs">
+                        {ep.description}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/RevokeTokenDialog.tsx
+++ b/frontend/src/components/settings/RevokeTokenDialog.tsx
@@ -1,0 +1,68 @@
+import { AlertTriangle } from "lucide-react";
+import type { TokenResponse } from "@/types/api-token";
+
+interface RevokeTokenDialogProps {
+  isOpen: boolean;
+  token: TokenResponse | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function RevokeTokenDialog({ isOpen, token, onClose, onConfirm }: RevokeTokenDialogProps) {
+  if (!isOpen || !token) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative bg-[#12121a] border border-[#1e1e2e] rounded-xl w-full max-w-md shadow-2xl mx-4">
+        <div className="px-6 py-5 space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="w-10 h-10 rounded-full bg-red-500/10 flex items-center justify-center flex-shrink-0">
+              <AlertTriangle className="w-5 h-5 text-red-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-white">Revoke API Key</h2>
+              <p className="text-sm text-gray-400 mt-1">
+                Are you sure you want to revoke{" "}
+                <span className="text-white font-medium">{token.name}</span>?
+              </p>
+            </div>
+          </div>
+
+          <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-4 py-3 space-y-1">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-500">Name</span>
+              <span className="text-sm text-white">{token.name}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-gray-500">Prefix</span>
+              <span className="text-sm text-gray-300 font-mono">{token.prefix}...</span>
+            </div>
+          </div>
+
+          <div className="flex items-start gap-2 px-3 py-2.5 bg-red-500/5 border border-red-500/10 rounded-lg">
+            <AlertTriangle className="w-4 h-4 text-red-400 flex-shrink-0 mt-0.5" />
+            <p className="text-xs text-red-300/80">
+              This action takes effect immediately. Any applications using this key will lose access.
+            </p>
+          </div>
+
+          <div className="flex items-center justify-end gap-3 pt-1">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 text-sm text-gray-400 hover:text-white border border-[#1e1e2e] hover:border-gray-700 rounded-lg transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={onConfirm}
+              className="px-4 py-2 text-sm font-medium text-white bg-red-600 hover:bg-red-500 rounded-lg transition-colors"
+            >
+              Revoke Key
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/ScopeCheckboxGrid.tsx
+++ b/frontend/src/components/settings/ScopeCheckboxGrid.tsx
@@ -1,0 +1,74 @@
+import { SCOPE_DEFINITIONS, SCOPE_MODULES } from "@/data/scopes";
+import type { TokenScope } from "@/types/api-token";
+
+interface ScopeCheckboxGridProps {
+  selectedScopes: string[];
+  onChange: (scopes: string[]) => void;
+}
+
+export function ScopeCheckboxGrid({ selectedScopes, onChange }: ScopeCheckboxGridProps) {
+  const allNonAdminScopes = SCOPE_DEFINITIONS
+    .filter((s) => s.scope !== "admin:*")
+    .map((s) => s.scope);
+
+  const isAdminSelected = selectedScopes.includes("admin:*");
+
+  const handleToggleScope = (scope: TokenScope) => {
+    if (scope === "admin:*") {
+      if (isAdminSelected) {
+        onChange([]);
+      } else {
+        onChange(["admin:*", ...allNonAdminScopes]);
+      }
+      return;
+    }
+    const next = selectedScopes.includes(scope)
+      ? selectedScopes.filter((s) => s !== scope && s !== "admin:*")
+      : [...selectedScopes, scope];
+    onChange(next);
+  };
+
+  const groupedByModule = SCOPE_MODULES.map((mod) => ({
+    module: mod,
+    scopes: SCOPE_DEFINITIONS.filter((s) => s.module === mod),
+  }));
+
+  return (
+    <div className="space-y-4">
+      {groupedByModule.map(({ module, scopes }) => (
+        <div key={module}>
+          <h4 className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">
+            {module}
+          </h4>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {scopes.map((scopeInfo) => {
+              const checked =
+                selectedScopes.includes(scopeInfo.scope) || isAdminSelected;
+              return (
+                <label
+                  key={scopeInfo.scope}
+                  className="flex items-start gap-2.5 px-3 py-2 rounded-lg bg-[#0a0a0f] border border-[#1e1e2e] hover:border-gray-700 cursor-pointer transition-colors group"
+                  title={scopeInfo.description}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => handleToggleScope(scopeInfo.scope)}
+                    disabled={scopeInfo.scope !== "admin:*" && isAdminSelected}
+                    className="mt-0.5 w-4 h-4 rounded border-gray-600 bg-gray-800 text-indigo-600 focus:ring-indigo-500 focus:ring-offset-0"
+                  />
+                  <div className="min-w-0">
+                    <span className="text-sm text-white block">{scopeInfo.label}</span>
+                    <span className="text-xs text-gray-500 block leading-tight">
+                      {scopeInfo.description}
+                    </span>
+                  </div>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/TokenCreatedView.tsx
+++ b/frontend/src/components/settings/TokenCreatedView.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { Copy, Check, AlertTriangle } from "lucide-react";
+import type { TokenCreatedResponse } from "@/types/api-token";
+
+interface TokenCreatedViewProps {
+  token: TokenCreatedResponse;
+  onClose: () => void;
+}
+
+export function TokenCreatedView({ token, onClose }: TokenCreatedViewProps) {
+  const [copied, setCopied] = useState(false);
+  const [curlCopied, setCurlCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(token.plain_token);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const curlSnippet = `curl -H "Authorization: Bearer ${token.plain_token}" \\
+  ${window.location.origin}/api/v1/documents`;
+
+  const handleCopyCurl = async () => {
+    await navigator.clipboard.writeText(curlSnippet);
+    setCurlCopied(true);
+    setTimeout(() => setCurlCopied(false), 2000);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
+      <div className="relative bg-[#12121a] border border-[#1e1e2e] rounded-xl w-full max-w-lg shadow-2xl mx-4">
+        <div className="px-6 py-5 space-y-5">
+          <div>
+            <h2 className="text-lg font-semibold text-white">API Key Created</h2>
+            <p className="text-sm text-gray-400 mt-1">
+              Your new API key <span className="text-white font-medium">{token.name}</span> has been created.
+            </p>
+          </div>
+
+          {/* Warning */}
+          <div className="flex items-start gap-3 px-4 py-3 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+            <AlertTriangle className="w-5 h-5 text-amber-400 flex-shrink-0 mt-0.5" />
+            <div>
+              <p className="text-sm font-medium text-amber-300">
+                Copy your key now
+              </p>
+              <p className="text-xs text-amber-400/80 mt-0.5">
+                This is the only time the full key will be shown. Store it securely.
+              </p>
+            </div>
+          </div>
+
+          {/* Token display */}
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1.5">
+              API Key
+            </label>
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                readOnly
+                value={token.plain_token}
+                className="flex-1 bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white font-mono focus:outline-none"
+              />
+              <button
+                onClick={handleCopy}
+                className="flex items-center gap-1.5 px-3 py-2.5 text-sm font-medium border border-[#1e1e2e] hover:border-gray-700 rounded-lg transition-colors"
+              >
+                {copied ? (
+                  <>
+                    <Check className="w-4 h-4 text-emerald-400" />
+                    <span className="text-emerald-400">Copied!</span>
+                  </>
+                ) : (
+                  <>
+                    <Copy className="w-4 h-4 text-gray-400" />
+                    <span className="text-gray-400">Copy</span>
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Quick start */}
+          <div>
+            <label className="block text-xs font-medium text-gray-500 mb-1.5">
+              Quick Start
+            </label>
+            <div className="relative">
+              <pre className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-4 py-3 text-xs text-gray-300 font-mono overflow-x-auto whitespace-pre-wrap">
+                {curlSnippet}
+              </pre>
+              <button
+                onClick={handleCopyCurl}
+                className="absolute top-2 right-2 p-1.5 text-gray-500 hover:text-gray-300 rounded transition-colors"
+                title="Copy curl command"
+              >
+                {curlCopied ? (
+                  <Check className="w-3.5 h-3.5 text-emerald-400" />
+                ) : (
+                  <Copy className="w-3.5 h-3.5" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Done */}
+          <div className="flex justify-end pt-1">
+            <button
+              onClick={onClose}
+              className="px-5 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-500 rounded-lg transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/settings/TokenList.tsx
+++ b/frontend/src/components/settings/TokenList.tsx
@@ -1,0 +1,174 @@
+import { Edit, Trash2, Key } from "lucide-react";
+import type { TokenResponse } from "@/types/api-token";
+
+interface TokenListProps {
+  tokens: TokenResponse[];
+  onEdit: (token: TokenResponse) => void;
+  onRevoke: (token: TokenResponse) => void;
+}
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "\u2014";
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function getExpiryStatus(expiresAt: string | null): {
+  label: string;
+  className: string;
+} {
+  if (!expiresAt) return { label: "Never expires", className: "text-gray-500" };
+  const now = new Date();
+  const exp = new Date(expiresAt);
+  const daysLeft = Math.ceil((exp.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+  if (daysLeft < 0) return { label: "Expired", className: "text-red-400" };
+  if (daysLeft <= 7) return { label: `${daysLeft}d left`, className: "text-amber-400" };
+  return { label: formatDate(expiresAt), className: "text-gray-400" };
+}
+
+function ScopeBadge({ scope }: { scope: string }) {
+  return (
+    <span className="inline-block px-2 py-0.5 text-xs rounded-full bg-indigo-500/10 text-indigo-400 border border-indigo-500/20">
+      {scope}
+    </span>
+  );
+}
+
+function TypeBadge({ type }: { type: string }) {
+  const isLive = type === "live";
+  return (
+    <span
+      className={`inline-block px-2 py-0.5 text-xs rounded-full border ${
+        isLive
+          ? "bg-emerald-500/10 text-emerald-400 border-emerald-500/20"
+          : "bg-amber-500/10 text-amber-400 border-amber-500/20"
+      }`}
+    >
+      {type}
+    </span>
+  );
+}
+
+export function TokenList({ tokens, onEdit, onRevoke }: TokenListProps) {
+  if (tokens.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 px-4">
+        <div className="w-16 h-16 rounded-2xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mb-4">
+          <Key className="w-8 h-8 text-indigo-400" />
+        </div>
+        <h3 className="text-lg font-semibold text-white mb-1">No API keys yet</h3>
+        <p className="text-sm text-gray-500 text-center max-w-sm">
+          Create one to get started with programmatic access to the DocMind API.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-[#1e1e2e]">
+            <th className="text-left py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Name
+            </th>
+            <th className="text-left py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Prefix
+            </th>
+            <th className="text-left py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Scopes
+            </th>
+            <th className="text-left py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Type
+            </th>
+            <th className="text-left py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Created
+            </th>
+            <th className="text-left py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Last Used
+            </th>
+            <th className="text-left py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Expires
+            </th>
+            <th className="text-right py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Actions
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {tokens.map((token) => {
+            const expiry = getExpiryStatus(token.expires_at);
+            const isRevoked = !!token.revoked_at;
+            return (
+              <tr
+                key={token.id}
+                className={`border-b border-[#1e1e2e] hover:bg-white/[0.02] transition-colors ${
+                  isRevoked ? "opacity-50" : ""
+                }`}
+              >
+                <td className="py-3 px-4">
+                  <span className="text-white font-medium">{token.name}</span>
+                </td>
+                <td className="py-3 px-4">
+                  <code className="text-gray-400 font-mono text-xs">
+                    {token.prefix}...
+                  </code>
+                </td>
+                <td className="py-3 px-4">
+                  <div className="flex flex-wrap gap-1 max-w-xs">
+                    {token.scopes.slice(0, 3).map((scope) => (
+                      <ScopeBadge key={scope} scope={scope} />
+                    ))}
+                    {token.scopes.length > 3 && (
+                      <span className="text-xs text-gray-500">
+                        +{token.scopes.length - 3} more
+                      </span>
+                    )}
+                  </div>
+                </td>
+                <td className="py-3 px-4">
+                  <TypeBadge type={token.token_type} />
+                </td>
+                <td className="py-3 px-4 text-gray-400">
+                  {formatDate(token.created_at)}
+                </td>
+                <td className="py-3 px-4 text-gray-500">
+                  {token.last_used_at ? formatDate(token.last_used_at) : "Never used"}
+                </td>
+                <td className="py-3 px-4">
+                  <span className={expiry.className}>{expiry.label}</span>
+                </td>
+                <td className="py-3 px-4">
+                  {!isRevoked && (
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        onClick={() => onEdit(token)}
+                        className="p-1.5 text-gray-500 hover:text-gray-300 rounded-lg hover:bg-white/5 transition-colors"
+                        title="Edit"
+                      >
+                        <Edit className="w-4 h-4" />
+                      </button>
+                      <button
+                        onClick={() => onRevoke(token)}
+                        className="p-1.5 text-gray-500 hover:text-red-400 rounded-lg hover:bg-white/5 transition-colors"
+                        title="Revoke"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    </div>
+                  )}
+                  {isRevoked && (
+                    <span className="text-xs text-red-400/70">Revoked</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/data/endpoints.ts
+++ b/frontend/src/data/endpoints.ts
@@ -1,0 +1,301 @@
+import type { EndpointInfo } from "@/types/api-token";
+
+export const ENDPOINT_DEFINITIONS: EndpointInfo[] = [
+  // Documents
+  {
+    method: "GET",
+    path: "/api/v1/documents",
+    scope: "documents:read",
+    description: "List all documents",
+    module: "Documents",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/documents/{id}",
+    scope: "documents:read",
+    description: "Get a single document by ID",
+    module: "Documents",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/documents/{id}/file",
+    scope: "documents:read",
+    description: "Download the original document file",
+    module: "Documents",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/documents/search",
+    scope: "documents:read",
+    description: "Search documents by filename or content",
+    module: "Documents",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/documents",
+    scope: "documents:write",
+    description: "Upload a new document (PDF or image)",
+    module: "Documents",
+  },
+  {
+    method: "DELETE",
+    path: "/api/v1/documents/{id}",
+    scope: "documents:write",
+    description: "Delete a document and its associated data",
+    module: "Documents",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/documents/{id}/process",
+    scope: "documents:write",
+    description: "Process a document through the extraction pipeline (SSE)",
+    module: "Documents",
+  },
+
+  // Extractions
+  {
+    method: "GET",
+    path: "/api/v1/extractions/{document_id}",
+    scope: "extractions:read",
+    description: "Get extraction results for a document",
+    module: "Extractions",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/extractions/{document_id}/audit",
+    scope: "extractions:read",
+    description: "Get the extraction audit trail",
+    module: "Extractions",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/extractions/{document_id}/overlay",
+    scope: "extractions:read",
+    description: "Get bounding box overlay regions",
+    module: "Extractions",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/extractions/{document_id}/comparison",
+    scope: "extractions:read",
+    description: "Get field comparison data",
+    module: "Extractions",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/extractions/{document_id}/export",
+    scope: "extractions:read",
+    description: "Export extraction results",
+    module: "Extractions",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/extractions/{document_id}/process",
+    scope: "extractions:write",
+    description: "Process extraction for a document (SSE)",
+    module: "Extractions",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/extractions/classify",
+    scope: "extractions:write",
+    description: "Classify a document type",
+    module: "Extractions",
+  },
+
+  // Chat (document-level)
+  {
+    method: "POST",
+    path: "/api/v1/chat/{document_id}",
+    scope: "documents:write",
+    description: "Send a chat message about a document (SSE)",
+    module: "Documents",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/chat/{document_id}/history",
+    scope: "documents:read",
+    description: "Get chat history for a document",
+    module: "Documents",
+  },
+
+  // Templates
+  {
+    method: "GET",
+    path: "/api/v1/templates",
+    scope: "templates:read",
+    description: "List all extraction templates",
+    module: "Templates",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/templates",
+    scope: "templates:write",
+    description: "Create a new extraction template",
+    module: "Templates",
+  },
+
+  // Projects
+  {
+    method: "GET",
+    path: "/api/v1/projects",
+    scope: "projects:read",
+    description: "List all projects",
+    module: "Projects",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/projects/{id}",
+    scope: "projects:read",
+    description: "Get a single project by ID",
+    module: "Projects",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/projects",
+    scope: "projects:write",
+    description: "Create a new project",
+    module: "Projects",
+  },
+  {
+    method: "PUT",
+    path: "/api/v1/projects/{id}",
+    scope: "projects:write",
+    description: "Update an existing project",
+    module: "Projects",
+  },
+  {
+    method: "DELETE",
+    path: "/api/v1/projects/{id}",
+    scope: "projects:write",
+    description: "Delete a project",
+    module: "Projects",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/projects/{id}/documents",
+    scope: "projects:write",
+    description: "Add a document to a project",
+    module: "Projects",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/projects/{id}/documents",
+    scope: "projects:read",
+    description: "List documents in a project",
+    module: "Projects",
+  },
+  {
+    method: "DELETE",
+    path: "/api/v1/projects/{id}/documents/{doc_id}",
+    scope: "projects:write",
+    description: "Remove a document from a project",
+    module: "Projects",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/projects/{id}/chat",
+    scope: "projects:chat",
+    description: "Send a chat message in a project conversation (SSE)",
+    module: "Projects",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/projects/{id}/conversations",
+    scope: "projects:read",
+    description: "List conversations in a project",
+    module: "Projects",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/projects/{id}/conversations/{conv_id}",
+    scope: "projects:read",
+    description: "Get a single conversation with messages",
+    module: "Projects",
+  },
+  {
+    method: "DELETE",
+    path: "/api/v1/projects/{id}/conversations/{conv_id}",
+    scope: "projects:write",
+    description: "Delete a conversation",
+    module: "Projects",
+  },
+
+  // Personas
+  {
+    method: "GET",
+    path: "/api/v1/personas",
+    scope: "personas:read",
+    description: "List all AI personas",
+    module: "Personas",
+  },
+  {
+    method: "POST",
+    path: "/api/v1/personas",
+    scope: "personas:write",
+    description: "Create a new AI persona",
+    module: "Personas",
+  },
+  {
+    method: "PUT",
+    path: "/api/v1/personas/{id}",
+    scope: "personas:write",
+    description: "Update an existing persona",
+    module: "Personas",
+  },
+  {
+    method: "DELETE",
+    path: "/api/v1/personas/{id}",
+    scope: "personas:write",
+    description: "Delete a persona",
+    module: "Personas",
+  },
+
+  // RAG
+  {
+    method: "POST",
+    path: "/api/v1/rag/search",
+    scope: "rag:read",
+    description: "Search the RAG index with a query",
+    module: "RAG",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/rag/chunks",
+    scope: "rag:read",
+    description: "List RAG chunks with optional filters",
+    module: "RAG",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/rag/chunks/{chunk_id}",
+    scope: "rag:read",
+    description: "Get a single RAG chunk by ID",
+    module: "RAG",
+  },
+  {
+    method: "GET",
+    path: "/api/v1/rag/stats",
+    scope: "rag:read",
+    description: "Get RAG index statistics",
+    module: "RAG",
+  },
+
+  // Analytics
+  {
+    method: "GET",
+    path: "/api/v1/analytics/summary",
+    scope: "documents:read",
+    description: "Get analytics summary (document counts, storage, etc.)",
+    module: "Documents",
+  },
+];
+
+export const ENDPOINT_MODULES = [
+  "Documents",
+  "Extractions",
+  "Templates",
+  "Projects",
+  "Personas",
+  "RAG",
+] as const;

--- a/frontend/src/data/scopes.ts
+++ b/frontend/src/data/scopes.ts
@@ -1,0 +1,105 @@
+import type { ScopeInfo } from "@/types/api-token";
+
+export const SCOPE_DEFINITIONS: ScopeInfo[] = [
+  // Documents
+  {
+    scope: "documents:read",
+    label: "Read Documents",
+    description: "List, view, and download documents",
+    module: "Documents",
+  },
+  {
+    scope: "documents:write",
+    label: "Write Documents",
+    description: "Upload, update, and delete documents",
+    module: "Documents",
+  },
+
+  // Extractions
+  {
+    scope: "extractions:read",
+    label: "Read Extractions",
+    description: "View extraction results, audit trails, overlays, and comparisons",
+    module: "Extractions",
+  },
+  {
+    scope: "extractions:write",
+    label: "Write Extractions",
+    description: "Process documents, classify, and export extractions",
+    module: "Extractions",
+  },
+
+  // Projects
+  {
+    scope: "projects:read",
+    label: "Read Projects",
+    description: "List and view projects, conversations, and project documents",
+    module: "Projects",
+  },
+  {
+    scope: "projects:write",
+    label: "Write Projects",
+    description: "Create, update, and delete projects and project documents",
+    module: "Projects",
+  },
+  {
+    scope: "projects:chat",
+    label: "Project Chat",
+    description: "Send messages in project conversations",
+    module: "Projects",
+  },
+
+  // RAG
+  {
+    scope: "rag:read",
+    label: "Read RAG",
+    description: "Search RAG index, view chunks and statistics",
+    module: "RAG",
+  },
+
+  // Templates
+  {
+    scope: "templates:read",
+    label: "Read Templates",
+    description: "List and view extraction templates",
+    module: "Templates",
+  },
+  {
+    scope: "templates:write",
+    label: "Write Templates",
+    description: "Create, update, and delete extraction templates",
+    module: "Templates",
+  },
+
+  // Personas
+  {
+    scope: "personas:read",
+    label: "Read Personas",
+    description: "List and view AI personas",
+    module: "Personas",
+  },
+  {
+    scope: "personas:write",
+    label: "Write Personas",
+    description: "Create, update, and delete AI personas",
+    module: "Personas",
+  },
+
+  // Admin
+  {
+    scope: "admin:*",
+    label: "Admin (Full Access)",
+    description: "Full access to all API endpoints and administrative actions",
+    module: "Admin",
+  },
+];
+
+export const SCOPE_MODULES = [
+  "Documents",
+  "Extractions",
+  "Projects",
+  "RAG",
+  "Templates",
+  "Personas",
+  "Admin",
+] as const;

--- a/frontend/src/hooks/useApiTokens.ts
+++ b/frontend/src/hooks/useApiTokens.ts
@@ -1,0 +1,53 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { listTokens, createToken, updateToken, revokeToken } from "@/lib/api";
+import type { CreateTokenRequest, UpdateTokenRequest } from "@/types/api-token";
+
+export function useTokens() {
+  return useQuery({
+    queryKey: ["api-tokens"],
+    queryFn: listTokens,
+  });
+}
+
+export function useCreateToken() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateTokenRequest) => createToken(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["api-tokens"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to create token: ${error.message}`);
+    },
+  });
+}
+
+export function useUpdateToken() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateTokenRequest }) =>
+      updateToken(id, data),
+    onSuccess: () => {
+      toast.success("API key updated");
+      queryClient.invalidateQueries({ queryKey: ["api-tokens"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to update token: ${error.message}`);
+    },
+  });
+}
+
+export function useRevokeToken() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => revokeToken(id),
+    onSuccess: () => {
+      toast.success("API key revoked");
+      queryClient.invalidateQueries({ queryKey: ["api-tokens"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to revoke token: ${error.message}`);
+    },
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -291,3 +291,34 @@ export async function deletePersona(id: string): Promise<void> {
 export async function duplicatePersona(id: string): Promise<PersonaResponse> {
   return apiFetch<PersonaResponse>(`/api/v1/personas/${id}/duplicate`, { method: "POST" });
 }
+
+// API Tokens
+import type {
+  TokenListResponse,
+  TokenCreatedResponse,
+  TokenResponse,
+  CreateTokenRequest,
+  UpdateTokenRequest,
+} from "@/types/api-token";
+
+export async function listTokens(): Promise<TokenListResponse> {
+  return apiFetch<TokenListResponse>("/api/v1/tokens");
+}
+
+export async function createToken(data: CreateTokenRequest): Promise<TokenCreatedResponse> {
+  return apiFetch<TokenCreatedResponse>("/api/v1/tokens", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateToken(id: string, data: UpdateTokenRequest): Promise<TokenResponse> {
+  return apiFetch<TokenResponse>(`/api/v1/tokens/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function revokeToken(id: string): Promise<void> {
+  await apiFetch<void>(`/api/v1/tokens/${id}`, { method: "DELETE" });
+}

--- a/frontend/src/pages/AboutSettings.tsx
+++ b/frontend/src/pages/AboutSettings.tsx
@@ -1,0 +1,28 @@
+export function AboutSettings() {
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-white">About</h2>
+        <p className="text-sm text-gray-400 mt-1">System information</p>
+      </div>
+      <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6 space-y-4">
+        <Field label="Version" value="0.2.0-alpha" />
+        <Field label="Stack" value="FastAPI + React + LangGraph + Supabase + pgvector" />
+        <Field label="VLM" value="Qwen-VL via DashScope" />
+        <Field label="RAG" value="pymupdf4llm + text-embedding-v4 + pgvector + hybrid search" />
+        <Field label="Templates" value="15 Indonesian document templates + custom" />
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-500 mb-1.5">{label}</label>
+      <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-gray-300">
+        {value || "\u2014"}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ApiKeysSettings.tsx
+++ b/frontend/src/pages/ApiKeysSettings.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Plus, Loader2, AlertCircle } from "lucide-react";
+import { useTokens, useRevokeToken } from "@/hooks/useApiTokens";
+import { TokenList } from "@/components/settings/TokenList";
+import { CreateTokenModal } from "@/components/settings/CreateTokenModal";
+import { TokenCreatedView } from "@/components/settings/TokenCreatedView";
+import { EditTokenModal } from "@/components/settings/EditTokenModal";
+import { RevokeTokenDialog } from "@/components/settings/RevokeTokenDialog";
+import type { TokenResponse, TokenCreatedResponse } from "@/types/api-token";
+
+export function ApiKeysSettings() {
+  const { data, isLoading, isError, error } = useTokens();
+  const revokeToken = useRevokeToken();
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [createdToken, setCreatedToken] = useState<TokenCreatedResponse | null>(null);
+  const [editingToken, setEditingToken] = useState<TokenResponse | null>(null);
+  const [revokingToken, setRevokingToken] = useState<TokenResponse | null>(null);
+
+  const handleCreated = (response: TokenCreatedResponse) => {
+    setShowCreate(false);
+    setCreatedToken(response);
+  };
+
+  const handleRevokeConfirm = () => {
+    if (revokingToken) {
+      revokeToken.mutate(revokingToken.id);
+      setRevokingToken(null);
+    }
+  };
+
+  const tokens = data?.tokens ?? [];
+
+  return (
+    <div>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-white">API Keys</h2>
+          <p className="text-sm text-gray-400 mt-1">
+            Create and manage API keys for programmatic access
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreate(true)}
+          className="flex items-center gap-2 px-4 py-2.5 bg-indigo-600 hover:bg-indigo-500 text-white text-sm font-medium rounded-lg transition-colors shadow-lg shadow-indigo-500/20"
+        >
+          <Plus className="w-4 h-4" />
+          Create API Key
+        </button>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <div className="flex flex-col items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 text-indigo-400 animate-spin" />
+          <p className="text-sm text-gray-500 mt-3">Loading API keys...</p>
+        </div>
+      ) : isError ? (
+        <div className="flex flex-col items-center justify-center py-20">
+          <AlertCircle className="w-8 h-8 text-red-400 mb-3" />
+          <p className="text-sm text-red-400">
+            Failed to load API keys: {(error as Error)?.message ?? "Unknown error"}
+          </p>
+        </div>
+      ) : (
+        <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl">
+          <TokenList
+            tokens={tokens}
+            onEdit={setEditingToken}
+            onRevoke={setRevokingToken}
+          />
+        </div>
+      )}
+
+      {/* Modals */}
+      <CreateTokenModal
+        isOpen={showCreate}
+        onClose={() => setShowCreate(false)}
+        onCreated={handleCreated}
+      />
+
+      {createdToken && (
+        <TokenCreatedView
+          token={createdToken}
+          onClose={() => setCreatedToken(null)}
+        />
+      )}
+
+      <EditTokenModal
+        isOpen={!!editingToken}
+        token={editingToken}
+        onClose={() => setEditingToken(null)}
+      />
+
+      <RevokeTokenDialog
+        isOpen={!!revokingToken}
+        token={revokingToken}
+        onClose={() => setRevokingToken(null)}
+        onConfirm={handleRevokeConfirm}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/ApiReference.tsx
+++ b/frontend/src/pages/ApiReference.tsx
@@ -1,0 +1,79 @@
+import { Shield, Key } from "lucide-react";
+import { EndpointTable } from "@/components/settings/EndpointTable";
+import { CodeExamples } from "@/components/settings/CodeExamples";
+
+export function ApiReference() {
+  return (
+    <div className="space-y-8">
+      {/* Header */}
+      <div>
+        <h2 className="text-xl font-semibold text-white">API Reference</h2>
+        <p className="text-sm text-gray-400 mt-1">
+          Learn how to authenticate and use the DocMind API
+        </p>
+      </div>
+
+      {/* Authentication section */}
+      <section className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6 space-y-4">
+        <div className="flex items-center gap-2 mb-1">
+          <Shield className="w-5 h-5 text-indigo-400" />
+          <h3 className="text-lg font-semibold text-white">Authentication</h3>
+        </div>
+        <p className="text-sm text-gray-400 leading-relaxed">
+          The DocMind API supports two authentication methods:
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Key className="w-4 h-4 text-indigo-400" />
+              <h4 className="text-sm font-medium text-white">API Key (recommended)</h4>
+            </div>
+            <p className="text-xs text-gray-400 mb-3">
+              Best for server-to-server integrations, CI/CD pipelines, and scripts.
+              Each key has scoped permissions.
+            </p>
+            <pre className="bg-[#12121a] border border-[#1e1e2e] rounded px-3 py-2 text-xs text-gray-300 font-mono">
+              Authorization: Bearer dm_live_xxxx
+            </pre>
+          </div>
+
+          <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Shield className="w-4 h-4 text-emerald-400" />
+              <h4 className="text-sm font-medium text-white">JWT Session Token</h4>
+            </div>
+            <p className="text-xs text-gray-400 mb-3">
+              Used by the web app. Obtained via the login endpoint.
+              Has full access for the authenticated user.
+            </p>
+            <pre className="bg-[#12121a] border border-[#1e1e2e] rounded px-3 py-2 text-xs text-gray-300 font-mono">
+              Authorization: Bearer eyJhbGci...
+            </pre>
+          </div>
+        </div>
+
+        <div className="bg-indigo-500/5 border border-indigo-500/10 rounded-lg px-4 py-3">
+          <p className="text-xs text-gray-400">
+            <span className="text-indigo-400 font-medium">Scoped access: </span>
+            API keys are restricted to the scopes you assign when creating them.
+            A key with <code className="text-indigo-300">documents:read</code> scope
+            can only read documents -- it cannot create or delete them.
+          </p>
+        </div>
+      </section>
+
+      {/* Endpoints section */}
+      <section className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Endpoints</h3>
+        <EndpointTable />
+      </section>
+
+      {/* Code Examples section */}
+      <section className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Code Examples</h3>
+        <CodeExamples />
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/PreferencesSettings.tsx
+++ b/frontend/src/pages/PreferencesSettings.tsx
@@ -1,0 +1,34 @@
+import { Shield } from "lucide-react";
+
+export function PreferencesSettings() {
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-white">Preferences</h2>
+        <p className="text-sm text-gray-400 mt-1">Application preferences and defaults</p>
+      </div>
+      <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6 space-y-4">
+        <Field label="Default VLM Provider" value="DashScope (Qwen-VL)" />
+        <Field label="Embedding Model" value="text-embedding-v4" />
+        <Field label="Theme" value="Dark" />
+        <div className="flex items-start gap-3 px-4 py-3 bg-indigo-500/5 border border-indigo-500/10 rounded-lg">
+          <Shield className="w-4 h-4 text-indigo-400 mt-0.5 flex-shrink-0" />
+          <p className="text-xs text-gray-400">
+            Editable preferences coming in a future update.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-500 mb-1.5">{label}</label>
+      <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-gray-300">
+        {value || "\u2014"}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfileSettings.tsx
+++ b/frontend/src/pages/ProfileSettings.tsx
@@ -1,0 +1,40 @@
+import { useAuthStore } from "@/stores/auth-store";
+
+export function ProfileSettings() {
+  const user = useAuthStore((s) => s.user);
+  const email = user?.email ?? "";
+  const initial = email ? email[0].toUpperCase() : "?";
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-white">Profile</h2>
+        <p className="text-sm text-gray-400 mt-1">Your account information</p>
+      </div>
+      <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6 space-y-4">
+        <div className="flex items-center gap-4 mb-4">
+          <div className="w-14 h-14 rounded-full bg-indigo-600/20 flex items-center justify-center text-indigo-400 text-xl font-semibold">
+            {initial}
+          </div>
+          <div>
+            <p className="text-sm text-white font-medium">{email || "Not signed in"}</p>
+            <p className="text-xs text-gray-500">Authenticated via Supabase</p>
+          </div>
+        </div>
+        <Field label="Email" value={email} />
+        <Field label="User ID" value={user?.id ?? ""} />
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-500 mb-1.5">{label}</label>
+      <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-gray-300">
+        {value || "\u2014"}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,101 +1,70 @@
-import { useState } from "react";
-import { useAuthStore } from "@/stores/auth-store";
-import { Shield, User, Palette, Info } from "lucide-react";
+import { NavLink, Outlet, Navigate, useLocation } from "react-router-dom";
+import { Key, Book, ArrowLeft, User, Palette, Info } from "lucide-react";
 
-type SettingsTab = "profile" | "preferences" | "about";
+const SIDEBAR_ITEMS = [
+  { to: "/settings/api-keys", label: "API Keys", icon: Key },
+  { to: "/settings/api-reference", label: "API Reference", icon: Book },
+  { to: "/settings/profile", label: "Profile", icon: User },
+  { to: "/settings/preferences", label: "Preferences", icon: Palette },
+  { to: "/settings/about", label: "About", icon: Info },
+];
 
 export function Settings() {
-  const [activeTab, setActiveTab] = useState<SettingsTab>("profile");
-  const user = useAuthStore((s) => s.user);
-  const email = user?.email ?? "";
-  const initial = email ? email[0].toUpperCase() : "?";
+  const location = useLocation();
 
-  const tabs: { id: SettingsTab; label: string; icon: React.ElementType }[] = [
-    { id: "profile", label: "Profile", icon: User },
-    { id: "preferences", label: "Preferences", icon: Palette },
-    { id: "about", label: "About", icon: Info },
-  ];
+  // Redirect bare /settings to /settings/api-keys
+  if (location.pathname === "/settings") {
+    return <Navigate to="/settings/api-keys" replace />;
+  }
 
   return (
-    <div className="max-w-4xl mx-auto px-6 py-8">
-      <div className="mb-8">
-        <h1 className="text-xl font-bold text-white">Settings</h1>
-        <p className="text-sm text-gray-400 mt-1">Manage your account and preferences</p>
-      </div>
-
-      <div className="flex gap-2 mb-6 border-b border-[#1e1e2e] pb-2">
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className={`flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
-              activeTab === tab.id
-                ? "bg-indigo-600/10 text-indigo-400"
-                : "text-gray-500 hover:text-gray-300 hover:bg-white/5"
-            }`}
-          >
-            <tab.icon className="w-4 h-4" />
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {activeTab === "profile" && <ProfileTab email={email} initial={initial} userId={user?.id ?? ""} />}
-      {activeTab === "preferences" && <PreferencesTab />}
-      {activeTab === "about" && <AboutTab />}
-    </div>
-  );
-}
-
-function ProfileTab({ email, initial, userId }: { email: string; initial: string; userId: string }) {
-  return (
-    <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6 space-y-4">
-      <div className="flex items-center gap-4 mb-4">
-        <div className="w-14 h-14 rounded-full bg-indigo-600/20 flex items-center justify-center text-indigo-400 text-xl font-semibold">
-          {initial}
-        </div>
+    <div className="max-w-6xl mx-auto px-6 py-8">
+      {/* Header */}
+      <div className="flex items-center gap-3 mb-6">
+        <NavLink
+          to="/dashboard"
+          className="p-1.5 text-gray-500 hover:text-gray-300 rounded-lg hover:bg-white/5 transition-colors"
+          title="Back to Dashboard"
+        >
+          <ArrowLeft className="w-5 h-5" />
+        </NavLink>
         <div>
-          <p className="text-sm text-white font-medium">{email || "Not signed in"}</p>
-          <p className="text-xs text-gray-500">Authenticated via Supabase</p>
+          <h1 className="text-xl font-bold text-white">Settings</h1>
+          <p className="text-sm text-gray-400 mt-0.5">
+            Manage your account, API keys, and preferences
+          </p>
         </div>
       </div>
-      <Field label="Email" value={email} />
-      <Field label="User ID" value={userId} />
-    </div>
-  );
-}
 
-function PreferencesTab() {
-  return (
-    <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6 space-y-4">
-      <Field label="Default VLM Provider" value="DashScope (Qwen-VL)" />
-      <Field label="Embedding Model" value="text-embedding-v4" />
-      <Field label="Theme" value="Dark" />
-      <div className="flex items-start gap-3 px-4 py-3 bg-indigo-500/5 border border-indigo-500/10 rounded-lg">
-        <Shield className="w-4 h-4 text-indigo-400 mt-0.5 flex-shrink-0" />
-        <p className="text-xs text-gray-400">Editable preferences coming in a future update.</p>
+      {/* Layout: sidebar + content */}
+      <div className="flex gap-6">
+        {/* Sidebar nav */}
+        <nav className="w-52 flex-shrink-0">
+          <div className="space-y-1">
+            {SIDEBAR_ITEMS.map((item) => (
+              <NavLink
+                key={item.to}
+                to={item.to}
+                className={({ isActive }) =>
+                  `flex items-center gap-2.5 px-3 py-2 text-sm font-medium rounded-lg transition-colors ${
+                    isActive
+                      ? "bg-indigo-600/10 text-indigo-400"
+                      : "text-gray-500 hover:text-gray-300 hover:bg-white/5"
+                  }`
+                }
+              >
+                <item.icon className="w-4 h-4" />
+                {item.label}
+              </NavLink>
+            ))}
+          </div>
+        </nav>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <Outlet />
+        </div>
       </div>
-    </div>
-  );
-}
-
-function AboutTab() {
-  return (
-    <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6 space-y-4">
-      <Field label="Version" value="0.2.0-alpha" />
-      <Field label="Stack" value="FastAPI + React + LangGraph + Supabase + pgvector" />
-      <Field label="VLM" value="Qwen-VL via DashScope" />
-      <Field label="RAG" value="pymupdf4llm + text-embedding-v4 + pgvector + hybrid search" />
-      <Field label="Templates" value="15 Indonesian document templates + custom" />
-    </div>
-  );
-}
-
-function Field({ label, value }: { label: string; value: string }) {
-  return (
-    <div>
-      <label className="block text-xs font-medium text-gray-500 mb-1.5">{label}</label>
-      <div className="bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-gray-300">{value || "\u2014"}</div>
     </div>
   );
 }

--- a/frontend/src/types/api-token.ts
+++ b/frontend/src/types/api-token.ts
@@ -1,0 +1,56 @@
+export type TokenScope =
+  | "documents:read" | "documents:write"
+  | "extractions:read" | "extractions:write"
+  | "projects:read" | "projects:write" | "projects:chat"
+  | "rag:read"
+  | "templates:read" | "templates:write"
+  | "personas:read" | "personas:write"
+  | "admin:*";
+
+export interface ScopeInfo {
+  scope: TokenScope;
+  label: string;
+  description: string;
+  module: string;
+}
+
+export interface CreateTokenRequest {
+  name: string;
+  scopes: TokenScope[];
+  token_type: "live" | "test";
+  expires_in_days: number | null;
+}
+
+export interface UpdateTokenRequest {
+  name?: string;
+  scopes?: TokenScope[];
+}
+
+export interface TokenResponse {
+  id: string;
+  name: string;
+  prefix: string;
+  scopes: string[];
+  token_type: string;
+  expires_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+export interface TokenCreatedResponse extends TokenResponse {
+  plain_token: string;
+}
+
+export interface TokenListResponse {
+  tokens: TokenResponse[];
+  total: number;
+}
+
+export interface EndpointInfo {
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+  path: string;
+  scope: TokenScope;
+  description: string;
+  module: string;
+}


### PR DESCRIPTION
## Summary

Complete API key experience: settings UI, token management, API reference docs, rate limiting, structured 403 errors.

### Backend (3 files modified, 2 new)
- Token validation rate limiter: 10 failures per 5min per prefix → 429
- Structured 403 response includes `missing_scope` field
- `AuthorizationException` now carries `detail` dict for enriched error info

### Frontend (14 new files, 3 modified)
- **Settings layout** with sidebar nav (API Keys, API Reference)
- **Token list table**: name, prefix (monospace), scope badges, type badge, dates, expiry warnings (yellow <7d, red expired)
- **Create token modal**: name input, live/test toggle, scope checkbox grid with descriptions, expiry dropdown
- **Token created view**: plain token (shown once), copy button with feedback, warning, curl quick start
- **Edit modal**: update name and scopes
- **Revoke dialog**: confirmation with token details
- **API Reference page**: authentication docs, 38 endpoints grouped by module (color-coded methods), code examples in cURL/Python/JavaScript with copy buttons
- **Scope data**: 13 scopes with labels and descriptions
- **React Query hooks**: useTokens, useCreateToken, useUpdateToken, useRevokeToken

## Test plan

- [x] 563 backend unit tests passing
- [x] 6 rate limiter tests (threshold, blocking, independent keys, window expiry, reset)
- [x] 5 scope enforcement tests passing
- [x] Frontend production build clean (687 KB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)