### PR TITLE
feat: AI Providers BYOK #96

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -75,5 +75,10 @@ CHAT_MAX_HISTORY=6
 CHAT_MAX_REQUERY_FIELDS=3
 CHAT_LOW_CONFIDENCE=0.6
 
+# ── Encryption ───────────────────────────────────────
+# Fernet key for encrypting user API keys (BYOK feature).
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+ENCRYPTION_KEY=
+
 # ── SSE ───────────────────────────────────────────────
 SSE_HEARTBEAT_TIMEOUT=30.0

--- a/backend/src/docmind/core/config.py
+++ b/backend/src/docmind/core/config.py
@@ -142,6 +142,12 @@ class Settings(BaseSettings):
     ENABLE_THINKING: bool = Field(default=True)
     THINKING_BUDGET: int = Field(default=10000)
 
+    # Encryption
+    ENCRYPTION_KEY: str = Field(
+        default="",
+        description="Fernet key for encrypting user API keys. Generate with Fernet.generate_key()",
+    )
+
     # CV Processing
     CV_DESKEW_THRESHOLD: float = Field(default=2.0)
     CV_QUALITY_GRID_SIZE: int = Field(default=4)

--- a/backend/src/docmind/core/encryption.py
+++ b/backend/src/docmind/core/encryption.py
@@ -1,0 +1,31 @@
+"""
+docmind/core/encryption.py
+
+Fernet-based encrypt/decrypt helpers for user API keys.
+Uses ENCRYPTION_KEY from application settings.
+"""
+
+from cryptography.fernet import Fernet
+
+from docmind.core.config import get_settings
+
+
+def _get_fernet() -> Fernet:
+    """Return a Fernet instance using the ENCRYPTION_KEY from settings."""
+    key = get_settings().ENCRYPTION_KEY
+    if not key:
+        raise RuntimeError(
+            "ENCRYPTION_KEY is not set. Generate one with: "
+            "python -c \"from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())\""
+        )
+    return Fernet(key.encode() if isinstance(key, str) else key)
+
+
+def encrypt(plaintext: str) -> str:
+    """Encrypt a plaintext string. Returns base64-encoded ciphertext."""
+    return _get_fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt(ciphertext: str) -> str:
+    """Decrypt a ciphertext string. Returns the original plaintext."""
+    return _get_fernet().decrypt(ciphertext.encode()).decode()

--- a/backend/src/docmind/dbase/psql/models/__init__.py
+++ b/backend/src/docmind/dbase/psql/models/__init__.py
@@ -13,6 +13,7 @@ from .project import Project
 from .project_conversation import ProjectConversation
 from .project_message import ProjectMessage
 from .template import Template
+from .user_provider_config import UserProviderConfig
 
 __all__ = [
     "ApiToken",
@@ -28,4 +29,5 @@ __all__ = [
     "ProjectConversation",
     "ProjectMessage",
     "Template",
+    "UserProviderConfig",
 ]

--- a/backend/src/docmind/dbase/psql/models/user_provider_config.py
+++ b/backend/src/docmind/dbase/psql/models/user_provider_config.py
@@ -1,0 +1,48 @@
+"""User Provider Config Model.
+
+Stores user-configured AI provider settings with encrypted API keys.
+One config per (user_id, provider_type) pair.
+"""
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from ..core.base import Base
+
+
+def _uuid() -> str:
+    return str(uuid.uuid4())
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class UserProviderConfig(Base):
+    __tablename__ = "user_provider_configs"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=_uuid)
+    user_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    provider_type: Mapped[str] = mapped_column(
+        String(20), nullable=False
+    )  # "vlm" | "embedding"
+    provider_name: Mapped[str] = mapped_column(
+        String(50), nullable=False
+    )  # "dashscope" | "openai" | "google" | "ollama"
+    encrypted_api_key: Mapped[str] = mapped_column(Text, nullable=False)
+    model_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    base_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    is_validated: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_now
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_now, onupdate=_now
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "provider_type", name="uq_user_provider_type"),
+    )

--- a/backend/src/docmind/library/providers/factory.py
+++ b/backend/src/docmind/library/providers/factory.py
@@ -3,11 +3,12 @@ docmind/library/providers/factory.py
 
 Factory function for creating VLM provider instances.
 
-Provider selection is driven by the VLM_PROVIDER environment variable.
-Each provider validates its own required env vars on construction.
+Provider selection is driven by the VLM_PROVIDER environment variable,
+or by user-level overrides passed via UserProviderOverride.
 """
 
 import logging
+from dataclasses import dataclass
 
 from docmind.core.config import get_settings
 from docmind.library.providers.protocol import VLMProvider
@@ -17,6 +18,16 @@ logger = logging.getLogger(__name__)
 # Provider registry — maps env var values to constructor callables.
 # Module-level singleton; classes are cached after first lazy import.
 _PROVIDER_REGISTRY: dict[str, type] = {}
+
+
+@dataclass(frozen=True)
+class UserProviderOverride:
+    """User-level provider override. API key must already be decrypted."""
+
+    provider_name: str
+    api_key: str
+    model_name: str
+    base_url: str | None = None
 
 
 def register_provider(name: str, cls: type) -> None:
@@ -29,28 +40,8 @@ def register_provider(name: str, cls: type) -> None:
     _PROVIDER_REGISTRY[name] = cls
 
 
-def get_vlm_provider() -> VLMProvider:
-    """Create and return the configured VLM provider.
-
-    Reads VLM_PROVIDER from settings to determine which provider to use.
-    Lazily imports the provider class on first use, then caches it in
-    the module-level registry. Each call creates a new provider instance.
-
-    Returns:
-        Configured VLMProvider instance.
-
-    Raises:
-        ValueError: If VLM_PROVIDER is not set or not recognized.
-        RuntimeError: If the provider's required env vars are missing.
-    """
-    settings = get_settings()
-    provider_name = settings.VLM_PROVIDER
-    if not provider_name:
-        raise ValueError(
-            "VLM_PROVIDER is not set. Options: dashscope, openai, google, ollama"
-        )
-
-    # Lazy imports to avoid loading unused provider dependencies
+def _ensure_registered(provider_name: str) -> None:
+    """Lazily import and register a provider class if not already registered."""
     if provider_name == "openrouter" and "openrouter" not in _PROVIDER_REGISTRY:
         from docmind.library.providers.openrouter import OpenRouterProvider
 
@@ -71,6 +62,51 @@ def get_vlm_provider() -> VLMProvider:
         from docmind.library.providers.ollama import OllamaProvider
 
         register_provider("ollama", OllamaProvider)
+
+
+def get_vlm_provider(
+    override: UserProviderOverride | None = None,
+) -> VLMProvider:
+    """Create and return a VLM provider.
+
+    If an override is provided, instantiate the specified provider with
+    the user's decrypted API key and model. Otherwise, fall back to the
+    system default from get_settings().
+
+    Args:
+        override: Optional user-level provider config (already decrypted).
+
+    Returns:
+        Configured VLMProvider instance.
+
+    Raises:
+        ValueError: If provider name is not set or not recognized.
+        RuntimeError: If the provider's required env vars are missing.
+    """
+    if override is not None:
+        provider_name = override.provider_name
+        _ensure_registered(provider_name)
+        provider_cls = _PROVIDER_REGISTRY.get(provider_name)
+        if provider_cls is None:
+            available = list(_PROVIDER_REGISTRY.keys())
+            raise ValueError(
+                f"Unknown VLM provider: '{provider_name}'. Available: {available}"
+            )
+        logger.info("Creating user-override VLM provider: %s", provider_name)
+        return provider_cls(
+            api_key=override.api_key,
+            model_name=override.model_name,
+            base_url=override.base_url,
+        )
+
+    settings = get_settings()
+    provider_name = settings.VLM_PROVIDER
+    if not provider_name:
+        raise ValueError(
+            "VLM_PROVIDER is not set. Options: dashscope, openai, google, ollama"
+        )
+
+    _ensure_registered(provider_name)
 
     provider_cls = _PROVIDER_REGISTRY.get(provider_name)
     if provider_cls is None:

--- a/backend/src/docmind/modules/settings/apiv1/handler.py
+++ b/backend/src/docmind/modules/settings/apiv1/handler.py
@@ -1,0 +1,127 @@
+"""
+docmind/modules/settings/apiv1/handler.py
+
+Provider settings HTTP endpoints — CRUD + test for user AI providers.
+"""
+
+from fastapi import APIRouter, Depends, Request
+
+from docmind.core.auth import get_current_user
+from docmind.core.logging import get_logger
+from docmind.modules.settings.dependencies import get_provider_settings_usecase
+from docmind.modules.settings.schemas import (
+    ProviderConfigResponse,
+    ProviderType,
+    ProvidersResponse,
+    SetProviderRequest,
+    ValidateProviderRequest,
+    ValidateProviderResponse,
+)
+from docmind.modules.settings.usecase import ProviderSettingsUseCase
+from docmind.shared.exceptions import AppException, BaseAppException
+
+logger = get_logger(__name__)
+router = APIRouter()
+
+
+@router.get("/providers", response_model=ProvidersResponse)
+async def get_providers(
+    request: Request,
+    usecase: ProviderSettingsUseCase = Depends(get_provider_settings_usecase),
+) -> ProvidersResponse:
+    """Get user's current provider configurations (API keys masked)."""
+    current_user = await get_current_user(request)
+    try:
+        return await usecase.get_providers(current_user["id"])
+    except BaseAppException:
+        raise
+    except Exception as exc:
+        logger.error("get_providers error: %s", exc, exc_info=True)
+        raise AppException(message="Internal server error") from exc
+
+
+@router.put("/providers/vlm", response_model=ProviderConfigResponse)
+async def set_vlm_provider(
+    body: SetProviderRequest,
+    request: Request,
+    usecase: ProviderSettingsUseCase = Depends(get_provider_settings_usecase),
+) -> ProviderConfigResponse:
+    """Set or update VLM provider configuration."""
+    current_user = await get_current_user(request)
+    try:
+        return await usecase.set_provider(
+            current_user["id"], ProviderType.VLM, body
+        )
+    except BaseAppException:
+        raise
+    except Exception as exc:
+        logger.error("set_vlm_provider error: %s", exc, exc_info=True)
+        raise AppException(message="Internal server error") from exc
+
+
+@router.put("/providers/embedding", response_model=ProviderConfigResponse)
+async def set_embedding_provider(
+    body: SetProviderRequest,
+    request: Request,
+    usecase: ProviderSettingsUseCase = Depends(get_provider_settings_usecase),
+) -> ProviderConfigResponse:
+    """Set or update embedding provider configuration."""
+    current_user = await get_current_user(request)
+    try:
+        return await usecase.set_provider(
+            current_user["id"], ProviderType.EMBEDDING, body
+        )
+    except BaseAppException:
+        raise
+    except Exception as exc:
+        logger.error("set_embedding_provider error: %s", exc, exc_info=True)
+        raise AppException(message="Internal server error") from exc
+
+
+@router.delete("/providers/vlm", status_code=204)
+async def delete_vlm_provider(
+    request: Request,
+    usecase: ProviderSettingsUseCase = Depends(get_provider_settings_usecase),
+) -> None:
+    """Remove VLM provider config (revert to system default)."""
+    current_user = await get_current_user(request)
+    try:
+        await usecase.delete_provider(current_user["id"], ProviderType.VLM)
+    except BaseAppException:
+        raise
+    except Exception as exc:
+        logger.error("delete_vlm_provider error: %s", exc, exc_info=True)
+        raise AppException(message="Internal server error") from exc
+
+
+@router.delete("/providers/embedding", status_code=204)
+async def delete_embedding_provider(
+    request: Request,
+    usecase: ProviderSettingsUseCase = Depends(get_provider_settings_usecase),
+) -> None:
+    """Remove embedding provider config (revert to system default)."""
+    current_user = await get_current_user(request)
+    try:
+        await usecase.delete_provider(current_user["id"], ProviderType.EMBEDDING)
+    except BaseAppException:
+        raise
+    except Exception as exc:
+        logger.error("delete_embedding_provider error: %s", exc, exc_info=True)
+        raise AppException(message="Internal server error") from exc
+
+
+@router.post("/providers/test", response_model=ValidateProviderResponse)
+async def test_provider(
+    body: ValidateProviderRequest,
+    request: Request,
+    usecase: ProviderSettingsUseCase = Depends(get_provider_settings_usecase),
+) -> ValidateProviderResponse:
+    """Test a provider connection without saving. Returns available models."""
+    await get_current_user(request)  # Ensure authenticated
+    try:
+        return await usecase.test_provider(body)
+    except BaseAppException:
+        raise
+    except Exception as exc:
+        logger.error("test_provider error: %s", exc, exc_info=True)
+        raise AppException(message="Internal server error") from exc

--- a/backend/src/docmind/modules/settings/dependencies.py
+++ b/backend/src/docmind/modules/settings/dependencies.py
@@ -1,0 +1,10 @@
+"""
+Dependency injection for settings module.
+"""
+
+from docmind.modules.settings.usecase import ProviderSettingsUseCase
+
+
+def get_provider_settings_usecase() -> ProviderSettingsUseCase:
+    """Create a ProviderSettingsUseCase instance."""
+    return ProviderSettingsUseCase()

--- a/backend/src/docmind/modules/settings/repositories.py
+++ b/backend/src/docmind/modules/settings/repositories.py
@@ -1,0 +1,95 @@
+"""
+User Provider Config repository — CRUD for user_provider_configs table.
+"""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import delete, select
+
+from docmind.core.logging import get_logger
+from docmind.dbase.psql.core.session import AsyncSessionLocal
+from docmind.dbase.psql.models.user_provider_config import UserProviderConfig
+
+logger = get_logger(__name__)
+
+
+class UserProviderRepository:
+    """Repository for user provider config CRUD operations."""
+
+    async def get_by_user_and_type(
+        self, user_id: str, provider_type: str
+    ) -> UserProviderConfig | None:
+        """Get a single config for a user and provider type."""
+        async with AsyncSessionLocal() as session:
+            stmt = select(UserProviderConfig).where(
+                UserProviderConfig.user_id == user_id,
+                UserProviderConfig.provider_type == provider_type,
+            )
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none()
+
+    async def get_all_for_user(self, user_id: str) -> list[UserProviderConfig]:
+        """Get all provider configs for a user."""
+        async with AsyncSessionLocal() as session:
+            stmt = (
+                select(UserProviderConfig)
+                .where(UserProviderConfig.user_id == user_id)
+                .order_by(UserProviderConfig.created_at.desc())
+            )
+            result = await session.execute(stmt)
+            return list(result.scalars().all())
+
+    async def upsert(
+        self,
+        user_id: str,
+        provider_type: str,
+        provider_name: str,
+        encrypted_api_key: str,
+        model_name: str,
+        base_url: str | None,
+        is_validated: bool,
+    ) -> UserProviderConfig:
+        """Insert or update a provider config for a user + type pair."""
+        async with AsyncSessionLocal() as session:
+            stmt = select(UserProviderConfig).where(
+                UserProviderConfig.user_id == user_id,
+                UserProviderConfig.provider_type == provider_type,
+            )
+            result = await session.execute(stmt)
+            existing = result.scalar_one_or_none()
+
+            if existing is not None:
+                existing.provider_name = provider_name
+                existing.encrypted_api_key = encrypted_api_key
+                existing.model_name = model_name
+                existing.base_url = base_url
+                existing.is_validated = is_validated
+                existing.updated_at = datetime.now(timezone.utc)
+                await session.commit()
+                await session.refresh(existing)
+                return existing
+
+            config = UserProviderConfig(
+                user_id=user_id,
+                provider_type=provider_type,
+                provider_name=provider_name,
+                encrypted_api_key=encrypted_api_key,
+                model_name=model_name,
+                base_url=base_url,
+                is_validated=is_validated,
+            )
+            session.add(config)
+            await session.commit()
+            await session.refresh(config)
+            return config
+
+    async def delete(self, user_id: str, provider_type: str) -> bool:
+        """Delete a provider config. Returns True if a row was deleted."""
+        async with AsyncSessionLocal() as session:
+            stmt = delete(UserProviderConfig).where(
+                UserProviderConfig.user_id == user_id,
+                UserProviderConfig.provider_type == provider_type,
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+            return result.rowcount > 0

--- a/backend/src/docmind/modules/settings/schemas.py
+++ b/backend/src/docmind/modules/settings/schemas.py
@@ -1,0 +1,66 @@
+"""
+docmind/modules/settings/schemas.py
+
+Pydantic models for provider configuration request/response serialization.
+"""
+
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+# ── Enums ────────────────────────────────────────────────
+
+
+class ProviderType(str, Enum):
+    VLM = "vlm"
+    EMBEDDING = "embedding"
+
+
+class ProviderName(str, Enum):
+    DASHSCOPE = "dashscope"
+    OPENAI = "openai"
+    GOOGLE = "google"
+    OLLAMA = "ollama"
+
+
+# ── Requests ─────────────────────────────────────────────
+
+
+class SetProviderRequest(BaseModel):
+    provider_name: ProviderName
+    api_key: str = Field(..., min_length=1, max_length=500)
+    model_name: str = Field(..., min_length=1, max_length=100)
+    base_url: str | None = Field(default=None, max_length=500)
+
+
+class ValidateProviderRequest(BaseModel):
+    provider_name: ProviderName
+    api_key: str = Field(..., min_length=1, max_length=500)
+    base_url: str | None = Field(default=None, max_length=500)
+
+
+# ── Responses ────────────────────────────────────────────
+
+
+class ValidateProviderResponse(BaseModel):
+    success: bool
+    models: list[str] = Field(default_factory=list)
+    error: str | None = None
+
+
+class ProviderConfigResponse(BaseModel):
+    provider_type: ProviderType
+    provider_name: ProviderName
+    model_name: str
+    base_url: str | None
+    is_validated: bool
+    api_key_prefix: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProvidersResponse(BaseModel):
+    vlm: ProviderConfigResponse | None = None
+    embedding: ProviderConfigResponse | None = None

--- a/backend/src/docmind/modules/settings/services.py
+++ b/backend/src/docmind/modules/settings/services.py
@@ -1,0 +1,203 @@
+"""
+Provider test service — validates provider connections and lists models.
+
+Business logic only, NO database access.
+"""
+
+import httpx
+
+from docmind.core.config import get_settings
+from docmind.core.logging import get_logger
+from docmind.modules.settings.schemas import ProviderName, ValidateProviderResponse
+
+logger = get_logger(__name__)
+
+_TEST_TIMEOUT = 15.0
+
+
+class ProviderTestService:
+    """Tests provider connections and retrieves available models."""
+
+    async def test_connection(
+        self,
+        provider_name: ProviderName,
+        api_key: str,
+        base_url: str | None = None,
+    ) -> ValidateProviderResponse:
+        """Test a provider connection and return available models."""
+        try:
+            if provider_name == ProviderName.DASHSCOPE:
+                return await self._test_dashscope(api_key, base_url)
+            elif provider_name == ProviderName.OPENAI:
+                return await self._test_openai(api_key, base_url)
+            elif provider_name == ProviderName.GOOGLE:
+                return await self._test_google(api_key)
+            elif provider_name == ProviderName.OLLAMA:
+                return await self._test_ollama(base_url)
+            else:
+                return ValidateProviderResponse(
+                    success=False,
+                    error=f"Unknown provider: {provider_name}",
+                )
+        except httpx.TimeoutException:
+            logger.warning("provider_test_timeout", provider=provider_name.value)
+            return ValidateProviderResponse(
+                success=False,
+                error=f"Connection timed out for {provider_name.value}",
+            )
+        except httpx.ConnectError:
+            logger.warning("provider_test_connect_error", provider=provider_name.value)
+            return ValidateProviderResponse(
+                success=False,
+                error=f"Could not connect to {provider_name.value}",
+            )
+        except Exception as exc:
+            logger.error(
+                "provider_test_error",
+                provider=provider_name.value,
+                error=str(exc),
+            )
+            return ValidateProviderResponse(
+                success=False,
+                error=f"Provider test failed: {exc}",
+            )
+
+    async def _test_dashscope(
+        self, api_key: str, base_url: str | None
+    ) -> ValidateProviderResponse:
+        """Test DashScope connection via models endpoint or generation fallback."""
+        settings = get_settings()
+        # Try the models listing endpoint first
+        models_url = base_url or "https://dashscope-intl.aliyuncs.com"
+        models_url = models_url.rstrip("/")
+
+        # If the base_url is the full generation URL, extract the base
+        if "/api/v1/services/" in models_url:
+            models_url = models_url.split("/api/v1/services/")[0]
+
+        async with httpx.AsyncClient(timeout=_TEST_TIMEOUT) as client:
+            # Try models endpoint
+            try:
+                resp = await client.get(
+                    f"{models_url}/api/v1/models",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                )
+                if resp.status_code == 200:
+                    data = resp.json()
+                    models = [
+                        m.get("id", m.get("model_id", ""))
+                        for m in data.get("data", data.get("models", []))
+                    ]
+                    return ValidateProviderResponse(success=True, models=models)
+            except Exception:
+                pass  # Fall through to generation endpoint test
+
+            # Fallback: test with a minimal generation request
+            gen_url = (
+                base_url
+                or settings.DASHSCOPE_BASE_URL
+            )
+            resp = await client.post(
+                gen_url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": settings.DASHSCOPE_MODEL,
+                    "input": {
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [{"text": "hi"}],
+                            }
+                        ]
+                    },
+                    "parameters": {"max_tokens": 1},
+                },
+            )
+            if resp.status_code == 200:
+                return ValidateProviderResponse(
+                    success=True,
+                    models=[settings.DASHSCOPE_MODEL],
+                )
+            return ValidateProviderResponse(
+                success=False,
+                error=f"Authentication failed (HTTP {resp.status_code})",
+            )
+
+    async def _test_openai(
+        self, api_key: str, base_url: str | None
+    ) -> ValidateProviderResponse:
+        """Test OpenAI connection via /v1/models endpoint."""
+        url = (base_url or "https://api.openai.com").rstrip("/")
+        async with httpx.AsyncClient(timeout=_TEST_TIMEOUT) as client:
+            resp = await client.get(
+                f"{url}/v1/models",
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            if resp.status_code != 200:
+                return ValidateProviderResponse(
+                    success=False,
+                    error=f"Authentication failed (HTTP {resp.status_code})",
+                )
+            data = resp.json()
+            all_models = [m["id"] for m in data.get("data", [])]
+            # Filter for vision-capable and embedding models
+            vision_keywords = ("gpt-4o", "gpt-4-turbo", "gpt-4-vision")
+            embedding_keywords = ("embedding",)
+            relevant = [
+                m
+                for m in all_models
+                if any(k in m for k in vision_keywords + embedding_keywords)
+            ]
+            return ValidateProviderResponse(
+                success=True,
+                models=sorted(relevant) if relevant else sorted(all_models[:20]),
+            )
+
+    async def _test_google(self, api_key: str) -> ValidateProviderResponse:
+        """Test Google Gemini connection via models listing endpoint."""
+        async with httpx.AsyncClient(timeout=_TEST_TIMEOUT) as client:
+            resp = await client.get(
+                "https://generativelanguage.googleapis.com/v1/models",
+                params={"key": api_key},
+            )
+            if resp.status_code != 200:
+                return ValidateProviderResponse(
+                    success=False,
+                    error=f"Authentication failed (HTTP {resp.status_code})",
+                )
+            data = resp.json()
+            models = []
+            for m in data.get("models", []):
+                name = m.get("name", "")
+                # Strip "models/" prefix
+                if name.startswith("models/"):
+                    name = name[7:]
+                methods = m.get("supportedGenerationMethods", [])
+                if "generateContent" in methods or "embedContent" in methods:
+                    models.append(name)
+            return ValidateProviderResponse(success=True, models=sorted(models))
+
+    async def _test_ollama(self, base_url: str | None) -> ValidateProviderResponse:
+        """Test Ollama connection via /api/tags endpoint."""
+        settings = get_settings()
+        url = (base_url or settings.OLLAMA_BASE_URL).rstrip("/")
+        async with httpx.AsyncClient(timeout=_TEST_TIMEOUT) as client:
+            resp = await client.get(f"{url}/api/tags")
+            if resp.status_code != 200:
+                return ValidateProviderResponse(
+                    success=False,
+                    error=f"Ollama returned HTTP {resp.status_code}",
+                )
+            data = resp.json()
+            models = [m["name"] for m in data.get("models", [])]
+            return ValidateProviderResponse(success=True, models=sorted(models))
+
+    @staticmethod
+    def mask_api_key(api_key: str) -> str:
+        """Return first 8 chars + '...' for display."""
+        if len(api_key) <= 8:
+            return api_key + "..."
+        return api_key[:8] + "..."

--- a/backend/src/docmind/modules/settings/usecase.py
+++ b/backend/src/docmind/modules/settings/usecase.py
@@ -1,0 +1,131 @@
+"""
+Provider settings use case — orchestrates service + repository calls.
+
+Handles encrypt-before-store and decrypt-at-read for API keys.
+"""
+
+from docmind.core.encryption import decrypt, encrypt
+from docmind.core.logging import get_logger
+from docmind.modules.settings.repositories import UserProviderRepository
+from docmind.modules.settings.schemas import (
+    ProviderConfigResponse,
+    ProviderName,
+    ProviderType,
+    ProvidersResponse,
+    SetProviderRequest,
+    ValidateProviderRequest,
+    ValidateProviderResponse,
+)
+from docmind.modules.settings.services import ProviderTestService
+from docmind.shared.exceptions import ValidationException
+
+logger = get_logger(__name__)
+
+
+class ProviderSettingsUseCase:
+    """Orchestrates provider settings CRUD and testing."""
+
+    def __init__(
+        self,
+        repository: UserProviderRepository | None = None,
+        service: ProviderTestService | None = None,
+    ) -> None:
+        self._repo = repository or UserProviderRepository()
+        self._service = service or ProviderTestService()
+
+    async def get_providers(self, user_id: str) -> ProvidersResponse:
+        """Get all provider configs for a user, with masked API keys."""
+        configs = await self._repo.get_all_for_user(user_id)
+        vlm_config = None
+        embedding_config = None
+
+        for config in configs:
+            # Decrypt key only to get the prefix for masking
+            try:
+                decrypted_key = decrypt(config.encrypted_api_key)
+                api_key_prefix = ProviderTestService.mask_api_key(decrypted_key)
+            except Exception:
+                logger.error(
+                    "failed_to_decrypt_api_key",
+                    user_id=user_id,
+                    provider_type=config.provider_type,
+                )
+                api_key_prefix = "***..."
+
+            response = ProviderConfigResponse(
+                provider_type=ProviderType(config.provider_type),
+                provider_name=ProviderName(config.provider_name),
+                model_name=config.model_name,
+                base_url=config.base_url,
+                is_validated=config.is_validated,
+                api_key_prefix=api_key_prefix,
+                created_at=config.created_at,
+                updated_at=config.updated_at,
+            )
+
+            if config.provider_type == ProviderType.VLM.value:
+                vlm_config = response
+            elif config.provider_type == ProviderType.EMBEDDING.value:
+                embedding_config = response
+
+        return ProvidersResponse(vlm=vlm_config, embedding=embedding_config)
+
+    async def set_provider(
+        self,
+        user_id: str,
+        provider_type: ProviderType,
+        request: SetProviderRequest,
+    ) -> ProviderConfigResponse:
+        """Set or update a provider config after testing the connection."""
+        # Test the provider connection first
+        test_result = await self._service.test_connection(
+            provider_name=request.provider_name,
+            api_key=request.api_key,
+            base_url=request.base_url,
+        )
+        if not test_result.success:
+            raise ValidationException(
+                f"Provider test failed: {test_result.error}"
+            )
+
+        # Encrypt the API key before storing
+        encrypted_key = encrypt(request.api_key)
+
+        config = await self._repo.upsert(
+            user_id=user_id,
+            provider_type=provider_type.value,
+            provider_name=request.provider_name.value,
+            encrypted_api_key=encrypted_key,
+            model_name=request.model_name,
+            base_url=request.base_url,
+            is_validated=True,
+        )
+
+        api_key_prefix = ProviderTestService.mask_api_key(request.api_key)
+
+        return ProviderConfigResponse(
+            provider_type=ProviderType(config.provider_type),
+            provider_name=ProviderName(config.provider_name),
+            model_name=config.model_name,
+            base_url=config.base_url,
+            is_validated=config.is_validated,
+            api_key_prefix=api_key_prefix,
+            created_at=config.created_at,
+            updated_at=config.updated_at,
+        )
+
+    async def delete_provider(
+        self, user_id: str, provider_type: ProviderType
+    ) -> bool:
+        """Delete a provider config. Returns True if deleted, False if not found."""
+        return await self._repo.delete(user_id, provider_type.value)
+
+    async def test_provider(
+        self, request: ValidateProviderRequest
+    ) -> ValidateProviderResponse:
+        """Test a provider connection without saving."""
+        return await self._service.test_connection(
+            provider_name=request.provider_name,
+            api_key=request.api_key,
+            base_url=request.base_url,
+        )

--- a/backend/src/docmind/router.py
+++ b/backend/src/docmind/router.py
@@ -16,6 +16,7 @@ from .modules.projects.apiv1.handler import router as projects_router
 from .modules.templates.apiv1.handler import router as templates_router
 from .modules.analytics.apiv1.handler import router as analytics_router
 from .modules.rag.apiv1.handler import router as rag_router
+from .modules.settings.apiv1.handler import router as settings_router
 
 api_router = APIRouter()
 
@@ -31,3 +32,4 @@ api_router.include_router(projects_router, prefix="/v1/projects", tags=["Project
 api_router.include_router(personas_router, prefix="/v1/personas", tags=["Personas"])
 api_router.include_router(analytics_router, prefix="/v1/analytics", tags=["Analytics"])
 api_router.include_router(rag_router, prefix="/v1/rag", tags=["RAG"])
+api_router.include_router(settings_router, prefix="/v1/settings", tags=["Settings"])

--- a/backend/tests/unit/core/test_encryption.py
+++ b/backend/tests/unit/core/test_encryption.py
@@ -1,0 +1,105 @@
+"""Tests for docmind.core.encryption module."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from cryptography.fernet import Fernet
+
+
+class TestEncryption:
+    """Tests for encrypt/decrypt functions."""
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_encrypt_decrypt_roundtrip(self, mock_settings: MagicMock) -> None:
+        key = Fernet.generate_key().decode()
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key)
+
+        from docmind.core.encryption import encrypt, decrypt
+
+        original = "sk-test-api-key-12345"
+        encrypted = encrypt(original)
+        assert encrypted != original
+        decrypted = decrypt(encrypted)
+        assert decrypted == original
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_different_plaintexts_different_ciphertexts(
+        self, mock_settings: MagicMock
+    ) -> None:
+        key = Fernet.generate_key().decode()
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key)
+
+        from docmind.core.encryption import encrypt
+
+        c1 = encrypt("key1")
+        c2 = encrypt("key2")
+        assert c1 != c2
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_same_plaintext_different_ciphertexts(
+        self, mock_settings: MagicMock
+    ) -> None:
+        """Fernet uses random IV, so same plaintext produces different ciphertext."""
+        key = Fernet.generate_key().decode()
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key)
+
+        from docmind.core.encryption import encrypt
+
+        c1 = encrypt("same-key")
+        c2 = encrypt("same-key")
+        assert c1 != c2  # Different IVs
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_empty_string_encryption(self, mock_settings: MagicMock) -> None:
+        key = Fernet.generate_key().decode()
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key)
+
+        from docmind.core.encryption import encrypt, decrypt
+
+        encrypted = encrypt("")
+        assert decrypt(encrypted) == ""
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_missing_key_raises(self, mock_settings: MagicMock) -> None:
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY="")
+
+        from docmind.core.encryption import encrypt
+
+        with pytest.raises(RuntimeError, match="ENCRYPTION_KEY"):
+            encrypt("test")
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_long_api_key(self, mock_settings: MagicMock) -> None:
+        key = Fernet.generate_key().decode()
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key)
+
+        from docmind.core.encryption import encrypt, decrypt
+
+        long_key = "sk-" + "a" * 200
+        encrypted = encrypt(long_key)
+        assert decrypt(encrypted) == long_key
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_unicode_plaintext(self, mock_settings: MagicMock) -> None:
+        key = Fernet.generate_key().decode()
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key)
+
+        from docmind.core.encryption import encrypt, decrypt
+
+        original = "key-with-unicode-chars"
+        encrypted = encrypt(original)
+        assert decrypt(encrypted) == original
+
+    @patch("docmind.core.encryption.get_settings")
+    def test_decrypt_with_wrong_key_raises(self, mock_settings: MagicMock) -> None:
+        key1 = Fernet.generate_key().decode()
+        key2 = Fernet.generate_key().decode()
+
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key1)
+        from docmind.core.encryption import encrypt, decrypt
+
+        encrypted = encrypt("secret")
+
+        mock_settings.return_value = MagicMock(ENCRYPTION_KEY=key2)
+        with pytest.raises(Exception):
+            decrypt(encrypted)

--- a/backend/tests/unit/modules/settings/test_provider_service.py
+++ b/backend/tests/unit/modules/settings/test_provider_service.py
@@ -1,0 +1,258 @@
+"""Tests for docmind.modules.settings.services.ProviderTestService."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+
+from docmind.modules.settings.schemas import ProviderName
+from docmind.modules.settings.services import ProviderTestService
+
+
+@pytest.fixture
+def service() -> ProviderTestService:
+    return ProviderTestService()
+
+
+class TestProviderTestServiceOpenAI:
+    """Test OpenAI provider connection testing."""
+
+    @pytest.mark.asyncio
+    async def test_openai_success(self, service: ProviderTestService) -> None:
+        mock_response = httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"id": "gpt-4o"},
+                    {"id": "gpt-4o-mini"},
+                    {"id": "text-embedding-ada-002"},
+                    {"id": "dall-e-3"},
+                ]
+            },
+            request=httpx.Request("GET", "https://api.openai.com/v1/models"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.test_connection(
+                provider_name=ProviderName.OPENAI,
+                api_key="sk-test-key",
+            )
+        assert result.success is True
+        assert "gpt-4o" in result.models
+        assert "text-embedding-ada-002" in result.models
+        # dall-e-3 should be filtered out (not vision or embedding)
+        assert "dall-e-3" not in result.models
+
+    @pytest.mark.asyncio
+    async def test_openai_auth_failure(self, service: ProviderTestService) -> None:
+        mock_response = httpx.Response(
+            401,
+            json={"error": {"message": "Invalid API key"}},
+            request=httpx.Request("GET", "https://api.openai.com/v1/models"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.test_connection(
+                provider_name=ProviderName.OPENAI,
+                api_key="sk-bad-key",
+            )
+        assert result.success is False
+        assert "401" in (result.error or "")
+
+
+class TestProviderTestServiceGoogle:
+    """Test Google Gemini provider connection testing."""
+
+    @pytest.mark.asyncio
+    async def test_google_success(self, service: ProviderTestService) -> None:
+        mock_response = httpx.Response(
+            200,
+            json={
+                "models": [
+                    {
+                        "name": "models/gemini-2.0-flash",
+                        "supportedGenerationMethods": ["generateContent"],
+                    },
+                    {
+                        "name": "models/text-embedding-004",
+                        "supportedGenerationMethods": ["embedContent"],
+                    },
+                    {
+                        "name": "models/some-other",
+                        "supportedGenerationMethods": ["other"],
+                    },
+                ]
+            },
+            request=httpx.Request("GET", "https://generativelanguage.googleapis.com/v1/models"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.test_connection(
+                provider_name=ProviderName.GOOGLE,
+                api_key="AIza-test-key",
+            )
+        assert result.success is True
+        assert "gemini-2.0-flash" in result.models
+        assert "text-embedding-004" in result.models
+        # "some-other" should be filtered out (no generateContent or embedContent)
+        assert "some-other" not in result.models
+
+    @pytest.mark.asyncio
+    async def test_google_auth_failure(self, service: ProviderTestService) -> None:
+        mock_response = httpx.Response(
+            400,
+            json={"error": {"message": "API key not valid"}},
+            request=httpx.Request("GET", "https://generativelanguage.googleapis.com/v1/models"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.test_connection(
+                provider_name=ProviderName.GOOGLE,
+                api_key="bad-key",
+            )
+        assert result.success is False
+        assert "400" in (result.error or "")
+
+
+class TestProviderTestServiceOllama:
+    """Test Ollama provider connection testing."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.settings.services.get_settings")
+    async def test_ollama_success(
+        self, mock_settings: MagicMock, service: ProviderTestService
+    ) -> None:
+        mock_settings.return_value = MagicMock(OLLAMA_BASE_URL="http://localhost:11434")
+        mock_response = httpx.Response(
+            200,
+            json={
+                "models": [
+                    {"name": "llava:latest"},
+                    {"name": "nomic-embed-text:latest"},
+                ]
+            },
+            request=httpx.Request("GET", "http://localhost:11434/api/tags"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.test_connection(
+                provider_name=ProviderName.OLLAMA,
+                api_key="unused",
+                base_url="http://localhost:11434",
+            )
+        assert result.success is True
+        assert "llava:latest" in result.models
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.settings.services.get_settings")
+    async def test_ollama_connect_error(
+        self, mock_settings: MagicMock, service: ProviderTestService
+    ) -> None:
+        mock_settings.return_value = MagicMock(OLLAMA_BASE_URL="http://localhost:11434")
+        with patch(
+            "httpx.AsyncClient.get",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("Connection refused"),
+        ):
+            result = await service.test_connection(
+                provider_name=ProviderName.OLLAMA,
+                api_key="unused",
+                base_url="http://localhost:11434",
+            )
+        assert result.success is False
+        assert "connect" in (result.error or "").lower()
+
+
+class TestProviderTestServiceDashScope:
+    """Test DashScope provider connection testing."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.settings.services.get_settings")
+    async def test_dashscope_models_endpoint_success(
+        self, mock_settings: MagicMock, service: ProviderTestService
+    ) -> None:
+        mock_settings.return_value = MagicMock(
+            DASHSCOPE_BASE_URL="https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation",
+            DASHSCOPE_MODEL="qwen-vl-max",
+        )
+        mock_response = httpx.Response(
+            200,
+            json={
+                "data": [
+                    {"id": "qwen-vl-max"},
+                    {"id": "qwen-vl-plus"},
+                ]
+            },
+            request=httpx.Request("GET", "https://dashscope-intl.aliyuncs.com/api/v1/models"),
+        )
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
+            result = await service.test_connection(
+                provider_name=ProviderName.DASHSCOPE,
+                api_key="sk-test-dashscope-key",
+            )
+        assert result.success is True
+        assert "qwen-vl-max" in result.models
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.settings.services.get_settings")
+    async def test_dashscope_fallback_generation_success(
+        self, mock_settings: MagicMock, service: ProviderTestService
+    ) -> None:
+        mock_settings.return_value = MagicMock(
+            DASHSCOPE_BASE_URL="https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation",
+            DASHSCOPE_MODEL="qwen-vl-max",
+        )
+        # Models endpoint fails, generation endpoint succeeds
+        models_fail = httpx.Response(
+            404,
+            json={},
+            request=httpx.Request("GET", "https://dashscope-intl.aliyuncs.com/api/v1/models"),
+        )
+        gen_success = httpx.Response(
+            200,
+            json={"output": {"text": "hi"}},
+            request=httpx.Request("POST", "https://dashscope-intl.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation"),
+        )
+
+        async def mock_get(*args, **kwargs):
+            return models_fail
+
+        async def mock_post(*args, **kwargs):
+            return gen_success
+
+        with patch("httpx.AsyncClient.get", new_callable=AsyncMock, side_effect=mock_get):
+            with patch("httpx.AsyncClient.post", new_callable=AsyncMock, side_effect=mock_post):
+                result = await service.test_connection(
+                    provider_name=ProviderName.DASHSCOPE,
+                    api_key="sk-test-key",
+                )
+        assert result.success is True
+
+
+class TestProviderTestServiceTimeout:
+    """Test timeout handling across providers."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_error(self, service: ProviderTestService) -> None:
+        with patch(
+            "httpx.AsyncClient.get",
+            new_callable=AsyncMock,
+            side_effect=httpx.TimeoutException("Timed out"),
+        ):
+            result = await service.test_connection(
+                provider_name=ProviderName.OPENAI,
+                api_key="sk-test-key",
+            )
+        assert result.success is False
+        assert "timed out" in (result.error or "").lower()
+
+
+class TestMaskApiKey:
+    """Test API key masking."""
+
+    def test_long_key(self) -> None:
+        assert ProviderTestService.mask_api_key("sk-proj-abcdefgh12345") == "sk-proj-..."
+
+    def test_short_key(self) -> None:
+        assert ProviderTestService.mask_api_key("short") == "short..."
+
+    def test_exact_8_chars(self) -> None:
+        assert ProviderTestService.mask_api_key("12345678") == "12345678..."
+
+    def test_longer_than_8(self) -> None:
+        assert ProviderTestService.mask_api_key("123456789") == "12345678..."

--- a/backend/tests/unit/modules/settings/test_usecase.py
+++ b/backend/tests/unit/modules/settings/test_usecase.py
@@ -1,0 +1,164 @@
+"""Tests for docmind.modules.settings.usecase.ProviderSettingsUseCase."""
+
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from docmind.modules.settings.schemas import (
+    ProviderName,
+    ProviderType,
+    SetProviderRequest,
+    ValidateProviderRequest,
+    ValidateProviderResponse,
+)
+from docmind.modules.settings.usecase import ProviderSettingsUseCase
+from docmind.shared.exceptions import ValidationException
+
+
+def _make_config(
+    provider_type: str = "vlm",
+    provider_name: str = "openai",
+    model_name: str = "gpt-4o",
+    encrypted_api_key: str = "encrypted-value",
+    is_validated: bool = True,
+) -> MagicMock:
+    config = MagicMock()
+    config.provider_type = provider_type
+    config.provider_name = provider_name
+    config.model_name = model_name
+    config.encrypted_api_key = encrypted_api_key
+    config.base_url = None
+    config.is_validated = is_validated
+    config.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    config.updated_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    return config
+
+
+@pytest.fixture
+def mock_repo() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_service() -> AsyncMock:
+    return AsyncMock()
+
+
+@pytest.fixture
+def usecase(mock_repo: AsyncMock, mock_service: AsyncMock) -> ProviderSettingsUseCase:
+    return ProviderSettingsUseCase(repository=mock_repo, service=mock_service)
+
+
+class TestGetProviders:
+    @pytest.mark.asyncio
+    @patch("docmind.modules.settings.usecase.decrypt", return_value="sk-decrypted-key")
+    async def test_returns_providers(
+        self, mock_decrypt: MagicMock, usecase: ProviderSettingsUseCase, mock_repo: AsyncMock
+    ) -> None:
+        mock_repo.get_all_for_user.return_value = [
+            _make_config(provider_type="vlm"),
+        ]
+        result = await usecase.get_providers("user-1")
+        assert result.vlm is not None
+        assert result.vlm.provider_name == ProviderName.OPENAI
+        assert result.vlm.api_key_prefix == "sk-decry..."
+        assert result.embedding is None
+
+    @pytest.mark.asyncio
+    async def test_empty_configs(
+        self, usecase: ProviderSettingsUseCase, mock_repo: AsyncMock
+    ) -> None:
+        mock_repo.get_all_for_user.return_value = []
+        result = await usecase.get_providers("user-1")
+        assert result.vlm is None
+        assert result.embedding is None
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.settings.usecase.decrypt", side_effect=Exception("bad key"))
+    async def test_decrypt_failure_returns_masked_prefix(
+        self, mock_decrypt: MagicMock, usecase: ProviderSettingsUseCase, mock_repo: AsyncMock
+    ) -> None:
+        mock_repo.get_all_for_user.return_value = [
+            _make_config(provider_type="vlm"),
+        ]
+        result = await usecase.get_providers("user-1")
+        assert result.vlm is not None
+        assert result.vlm.api_key_prefix == "***..."
+
+
+class TestSetProvider:
+    @pytest.mark.asyncio
+    @patch("docmind.modules.settings.usecase.encrypt", return_value="encrypted-value")
+    async def test_set_provider_success(
+        self,
+        mock_encrypt: MagicMock,
+        usecase: ProviderSettingsUseCase,
+        mock_repo: AsyncMock,
+        mock_service: AsyncMock,
+    ) -> None:
+        mock_service.test_connection.return_value = ValidateProviderResponse(
+            success=True, models=["gpt-4o"]
+        )
+        mock_repo.upsert.return_value = _make_config()
+
+        request = SetProviderRequest(
+            provider_name=ProviderName.OPENAI,
+            api_key="sk-real-key-12345",
+            model_name="gpt-4o",
+        )
+        result = await usecase.set_provider("user-1", ProviderType.VLM, request)
+        assert result.provider_name == ProviderName.OPENAI
+        assert result.is_validated is True
+        mock_encrypt.assert_called_once_with("sk-real-key-12345")
+
+    @pytest.mark.asyncio
+    async def test_set_provider_test_fails(
+        self,
+        usecase: ProviderSettingsUseCase,
+        mock_service: AsyncMock,
+    ) -> None:
+        mock_service.test_connection.return_value = ValidateProviderResponse(
+            success=False, error="Invalid API key"
+        )
+        request = SetProviderRequest(
+            provider_name=ProviderName.OPENAI,
+            api_key="sk-bad-key",
+            model_name="gpt-4o",
+        )
+        with pytest.raises(ValidationException, match="Provider test failed"):
+            await usecase.set_provider("user-1", ProviderType.VLM, request)
+
+
+class TestDeleteProvider:
+    @pytest.mark.asyncio
+    async def test_delete_existing(
+        self, usecase: ProviderSettingsUseCase, mock_repo: AsyncMock
+    ) -> None:
+        mock_repo.delete.return_value = True
+        result = await usecase.delete_provider("user-1", ProviderType.VLM)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent(
+        self, usecase: ProviderSettingsUseCase, mock_repo: AsyncMock
+    ) -> None:
+        mock_repo.delete.return_value = False
+        result = await usecase.delete_provider("user-1", ProviderType.VLM)
+        assert result is False
+
+
+class TestTestProvider:
+    @pytest.mark.asyncio
+    async def test_delegates_to_service(
+        self, usecase: ProviderSettingsUseCase, mock_service: AsyncMock
+    ) -> None:
+        mock_service.test_connection.return_value = ValidateProviderResponse(
+            success=True, models=["gpt-4o"]
+        )
+        request = ValidateProviderRequest(
+            provider_name=ProviderName.OPENAI,
+            api_key="sk-test-key",
+        )
+        result = await usecase.test_provider(request)
+        assert result.success is True
+        mock_service.test_connection.assert_called_once()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { ApiReference } from "@/pages/ApiReference";
 import { ProfileSettings } from "@/pages/ProfileSettings";
 import { PreferencesSettings } from "@/pages/PreferencesSettings";
 import { AboutSettings } from "@/pages/AboutSettings";
+import { AiProvidersSettings } from "@/pages/AiProvidersSettings";
 
 function AuthProvider({ children }: { children: React.ReactNode }) {
   const { setAuth, clearAuth, setIsLoading } = useAuthStore();
@@ -63,6 +64,7 @@ export function App() {
                   <Route path="/workspace/:documentId" element={<Workspace />} />
                   <Route path="/settings" element={<Settings />}>
                     <Route path="api-keys" element={<ApiKeysSettings />} />
+                    <Route path="ai-providers" element={<AiProvidersSettings />} />
                     <Route path="api-reference" element={<ApiReference />} />
                     <Route path="profile" element={<ProfileSettings />} />
                     <Route path="preferences" element={<PreferencesSettings />} />

--- a/frontend/src/components/settings/ProviderCard.tsx
+++ b/frontend/src/components/settings/ProviderCard.tsx
@@ -1,0 +1,452 @@
+import { useState } from "react";
+import {
+  Cpu,
+  Zap,
+  Eye,
+  EyeOff,
+  Check,
+  X,
+  Loader2,
+  Trash2,
+  Pencil,
+  ChevronDown,
+  Info,
+} from "lucide-react";
+import {
+  useSetProvider,
+  useDeleteProvider,
+  useTestProvider,
+} from "@/hooks/useProviderSettings";
+import type {
+  ProviderType,
+  ProviderName,
+  ProviderConfigResponse,
+} from "@/types/provider";
+
+interface ProviderCardProps {
+  type: ProviderType;
+  title: string;
+  description: string;
+  currentConfig: ProviderConfigResponse | null;
+}
+
+const PROVIDER_OPTIONS: { value: ProviderName; label: string }[] = [
+  { value: "dashscope", label: "DashScope (Qwen-VL)" },
+  { value: "openai", label: "OpenAI (GPT-4o)" },
+  { value: "google", label: "Google (Gemini)" },
+  { value: "ollama", label: "Ollama (Local)" },
+];
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function getProviderLabel(name: ProviderName): string {
+  return PROVIDER_OPTIONS.find((o) => o.value === name)?.label ?? name;
+}
+
+export function ProviderCard({
+  type,
+  title,
+  description,
+  currentConfig,
+}: ProviderCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [providerName, setProviderName] = useState<ProviderName>(
+    currentConfig?.provider_name ?? "dashscope",
+  );
+  const [apiKey, setApiKey] = useState("");
+  const [baseUrl, setBaseUrl] = useState(
+    currentConfig?.base_url ?? "http://localhost:11434",
+  );
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [modelName, setModelName] = useState(
+    currentConfig?.model_name ?? "",
+  );
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [testPassed, setTestPassed] = useState(false);
+  const [testError, setTestError] = useState<string | null>(null);
+  const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+
+  const setProviderMutation = useSetProvider();
+  const deleteProviderMutation = useDeleteProvider();
+  const testProviderMutation = useTestProvider();
+
+  const isConfigured = currentConfig !== null && !isEditing;
+  const showForm = !currentConfig || isEditing;
+
+  const resetForm = () => {
+    setProviderName(currentConfig?.provider_name ?? "dashscope");
+    setApiKey("");
+    setBaseUrl(currentConfig?.base_url ?? "http://localhost:11434");
+    setModelName(currentConfig?.model_name ?? "");
+    setAvailableModels([]);
+    setTestPassed(false);
+    setTestError(null);
+    setShowApiKey(false);
+  };
+
+  const handleEdit = () => {
+    resetForm();
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    resetForm();
+    setIsEditing(false);
+  };
+
+  const handleProviderChange = (name: ProviderName) => {
+    setProviderName(name);
+    setApiKey("");
+    setBaseUrl(name === "ollama" ? "http://localhost:11434" : "");
+    setModelName("");
+    setAvailableModels([]);
+    setTestPassed(false);
+    setTestError(null);
+  };
+
+  const handleTest = () => {
+    setTestError(null);
+    setTestPassed(false);
+    setAvailableModels([]);
+    setModelName("");
+
+    testProviderMutation.mutate(
+      {
+        provider_name: providerName,
+        api_key: apiKey,
+        base_url: providerName === "ollama" ? baseUrl : null,
+      },
+      {
+        onSuccess: (result) => {
+          if (result.success) {
+            setTestPassed(true);
+            setAvailableModels(result.models);
+            if (result.models.length === 1) {
+              setModelName(result.models[0]);
+            }
+          } else {
+            setTestError(result.error ?? "Connection test failed");
+          }
+        },
+        onError: (error) => {
+          setTestError(error.message);
+        },
+      },
+    );
+  };
+
+  const handleSave = () => {
+    setProviderMutation.mutate(
+      {
+        type,
+        data: {
+          provider_name: providerName,
+          api_key: apiKey,
+          model_name: modelName,
+          base_url: providerName === "ollama" ? baseUrl : null,
+        },
+      },
+      {
+        onSuccess: () => {
+          setIsEditing(false);
+          resetForm();
+        },
+      },
+    );
+  };
+
+  const handleRemove = () => {
+    deleteProviderMutation.mutate(type, {
+      onSuccess: () => {
+        setShowRemoveConfirm(false);
+        resetForm();
+        setIsEditing(false);
+      },
+    });
+  };
+
+  const TypeIcon = type === "vlm" ? Zap : Cpu;
+
+  return (
+    <div className="bg-[#12121a] border border-[#1e1e2e] rounded-xl p-6">
+      {/* Header */}
+      <div className="flex items-start gap-3 mb-4">
+        <div className="p-2 rounded-lg bg-indigo-600/10">
+          <TypeIcon className="w-5 h-5 text-indigo-400" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-base font-semibold text-white">{title}</h3>
+          <p className="text-sm text-gray-400 mt-0.5">{description}</p>
+        </div>
+      </div>
+
+      {/* Configured status view */}
+      {isConfigured && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4 bg-[#0a0a0f] rounded-lg p-4 border border-[#1e1e2e]">
+            <div>
+              <p className="text-xs text-gray-500 mb-1">Provider</p>
+              <p className="text-sm text-white font-medium">
+                {getProviderLabel(currentConfig.provider_name)}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 mb-1">Model</p>
+              <p className="text-sm text-white font-medium">
+                {currentConfig.model_name}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 mb-1">API Key</p>
+              <p className="text-sm text-gray-300 font-mono">
+                {currentConfig.api_key_prefix}{"****"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 mb-1">Last Updated</p>
+              <p className="text-sm text-gray-300">
+                {formatDate(currentConfig.updated_at)}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3">
+            {currentConfig.is_validated && (
+              <span className="flex items-center gap-1.5 text-xs text-emerald-400">
+                <Check className="w-3.5 h-3.5" />
+                Validated
+              </span>
+            )}
+            <div className="flex-1" />
+            <button
+              onClick={handleEdit}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+            >
+              <Pencil className="w-3.5 h-3.5" />
+              Edit
+            </button>
+            <button
+              onClick={() => setShowRemoveConfirm(true)}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-red-400 hover:text-red-300 hover:bg-red-500/10 rounded-lg transition-colors"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+              Remove
+            </button>
+          </div>
+
+          {/* Remove confirmation */}
+          {showRemoveConfirm && (
+            <div className="bg-red-500/5 border border-red-500/20 rounded-lg p-4">
+              <p className="text-sm text-red-300 mb-3">
+                Remove this provider? The system default will be used instead.
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleRemove}
+                  disabled={deleteProviderMutation.isPending}
+                  className="px-3 py-1.5 text-sm bg-red-600 hover:bg-red-500 text-white rounded-lg transition-colors disabled:opacity-50"
+                >
+                  {deleteProviderMutation.isPending ? "Removing..." : "Confirm Remove"}
+                </button>
+                <button
+                  onClick={() => setShowRemoveConfirm(false)}
+                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Form view */}
+      {showForm && (
+        <div className="space-y-4">
+          {/* Provider select */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Provider
+            </label>
+            <div className="relative">
+              <select
+                value={providerName}
+                onChange={(e) =>
+                  handleProviderChange(e.target.value as ProviderName)
+                }
+                className="w-full appearance-none bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white focus:outline-none focus:border-indigo-500 pr-10"
+              >
+                {PROVIDER_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none" />
+            </div>
+          </div>
+
+          {/* API Key */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              API Key
+            </label>
+            <div className="relative">
+              <input
+                type={showApiKey ? "text" : "password"}
+                value={apiKey}
+                onChange={(e) => {
+                  setApiKey(e.target.value);
+                  setTestPassed(false);
+                  setAvailableModels([]);
+                  setModelName("");
+                  setTestError(null);
+                }}
+                placeholder={
+                  providerName === "ollama"
+                    ? "Optional for local Ollama"
+                    : "Enter your API key"
+                }
+                className="w-full bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500 pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowApiKey(!showApiKey)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300"
+              >
+                {showApiKey ? (
+                  <EyeOff className="w-4 h-4" />
+                ) : (
+                  <Eye className="w-4 h-4" />
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Base URL (Ollama only) */}
+          {providerName === "ollama" && (
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                Base URL
+              </label>
+              <input
+                type="text"
+                value={baseUrl}
+                onChange={(e) => {
+                  setBaseUrl(e.target.value);
+                  setTestPassed(false);
+                  setAvailableModels([]);
+                  setModelName("");
+                  setTestError(null);
+                }}
+                placeholder="http://localhost:11434"
+                className="w-full bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-indigo-500"
+              />
+            </div>
+          )}
+
+          {/* Test Connection */}
+          <div className="flex items-center gap-3">
+            <button
+              onClick={handleTest}
+              disabled={
+                testProviderMutation.isPending ||
+                (!apiKey && providerName !== "ollama")
+              }
+              className="flex items-center gap-2 px-4 py-2 text-sm font-medium bg-[#0a0a0f] border border-[#1e1e2e] text-white rounded-lg hover:border-indigo-500/50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {testProviderMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Testing...
+                </>
+              ) : (
+                "Test Connection"
+              )}
+            </button>
+
+            {testPassed && (
+              <span className="flex items-center gap-1.5 text-sm text-emerald-400">
+                <Check className="w-4 h-4" />
+                Connected
+              </span>
+            )}
+            {testError && (
+              <span className="flex items-center gap-1.5 text-sm text-red-400 min-w-0">
+                <X className="w-4 h-4 flex-shrink-0" />
+                <span className="truncate">{testError}</span>
+              </span>
+            )}
+          </div>
+
+          {/* Model select */}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              Model
+            </label>
+            <div className="relative">
+              <select
+                value={modelName}
+                onChange={(e) => setModelName(e.target.value)}
+                disabled={!testPassed || availableModels.length === 0}
+                className="w-full appearance-none bg-[#0a0a0f] border border-[#1e1e2e] rounded-lg px-3 py-2.5 text-sm text-white focus:outline-none focus:border-indigo-500 pr-10 disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                <option value="">Select a model...</option>
+                {availableModels.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+              <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500 pointer-events-none" />
+            </div>
+            {!testPassed && (
+              <p className="text-xs text-gray-500 mt-1.5 flex items-center gap-1">
+                <Info className="w-3 h-3" />
+                Test connection first to see available models
+              </p>
+            )}
+          </div>
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              onClick={handleSave}
+              disabled={
+                !testPassed ||
+                !modelName ||
+                setProviderMutation.isPending
+              }
+              className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium bg-indigo-600 hover:bg-indigo-500 text-white rounded-lg transition-colors shadow-lg shadow-indigo-500/20 disabled:opacity-40 disabled:cursor-not-allowed disabled:shadow-none"
+            >
+              {setProviderMutation.isPending ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Saving...
+                </>
+              ) : (
+                "Save Provider"
+              )}
+            </button>
+            {currentConfig && (
+              <button
+                onClick={handleCancel}
+                className="px-4 py-2.5 text-sm text-gray-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors"
+              >
+                Cancel
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useProviderSettings.ts
+++ b/frontend/src/hooks/useProviderSettings.ts
@@ -1,0 +1,51 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  getProviders,
+  setProvider,
+  deleteProvider,
+  testProvider,
+} from "@/lib/api";
+import type { ProviderType, SetProviderRequest, ValidateProviderRequest } from "@/types/provider";
+
+export function useProviders() {
+  return useQuery({
+    queryKey: ["providers"],
+    queryFn: getProviders,
+  });
+}
+
+export function useSetProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ type, data }: { type: ProviderType; data: SetProviderRequest }) =>
+      setProvider(type, data),
+    onSuccess: () => {
+      toast.success("Provider saved");
+      queryClient.invalidateQueries({ queryKey: ["providers"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to save provider: ${error.message}`);
+    },
+  });
+}
+
+export function useDeleteProvider() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (type: ProviderType) => deleteProvider(type),
+    onSuccess: () => {
+      toast.success("Provider removed");
+      queryClient.invalidateQueries({ queryKey: ["providers"] });
+    },
+    onError: (error: Error) => {
+      toast.error(`Failed to remove provider: ${error.message}`);
+    },
+  });
+}
+
+export function useTestProvider() {
+  return useMutation({
+    mutationFn: (data: ValidateProviderRequest) => testProvider(data),
+  });
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -292,6 +292,45 @@ export async function duplicatePersona(id: string): Promise<PersonaResponse> {
   return apiFetch<PersonaResponse>(`/api/v1/personas/${id}/duplicate`, { method: "POST" });
 }
 
+// Provider Settings
+import type {
+  ProviderType,
+  ProvidersResponse,
+  ProviderConfigResponse,
+  SetProviderRequest,
+  ValidateProviderRequest,
+  ValidateProviderResponse,
+} from "@/types/provider";
+
+export async function getProviders(): Promise<ProvidersResponse> {
+  return apiFetch<ProvidersResponse>("/api/v1/settings/providers");
+}
+
+export async function setProvider(
+  type: ProviderType,
+  data: SetProviderRequest,
+): Promise<ProviderConfigResponse> {
+  return apiFetch<ProviderConfigResponse>(
+    `/api/v1/settings/providers/${type}`,
+    { method: "PUT", body: JSON.stringify(data) },
+  );
+}
+
+export async function deleteProvider(type: ProviderType): Promise<void> {
+  await apiFetch<void>(`/api/v1/settings/providers/${type}`, {
+    method: "DELETE",
+  });
+}
+
+export async function testProvider(
+  data: ValidateProviderRequest,
+): Promise<ValidateProviderResponse> {
+  return apiFetch<ValidateProviderResponse>(
+    "/api/v1/settings/providers/test",
+    { method: "POST", body: JSON.stringify(data) },
+  );
+}
+
 // API Tokens
 import type {
   TokenListResponse,

--- a/frontend/src/pages/AiProvidersSettings.tsx
+++ b/frontend/src/pages/AiProvidersSettings.tsx
@@ -1,0 +1,59 @@
+import { Loader2, AlertCircle, Info } from "lucide-react";
+import { useProviders } from "@/hooks/useProviderSettings";
+import { ProviderCard } from "@/components/settings/ProviderCard";
+
+export function AiProvidersSettings() {
+  const { data, isLoading, isError, error } = useProviders();
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div>
+        <h2 className="text-xl font-semibold text-white">AI Providers</h2>
+        <p className="text-sm text-gray-400 mt-1">
+          Configure your own API keys for VLM and embedding providers
+        </p>
+      </div>
+
+      {/* Info box */}
+      <div className="flex items-start gap-3 bg-indigo-600/5 border border-indigo-500/20 rounded-xl px-4 py-3">
+        <Info className="w-4 h-4 text-indigo-400 mt-0.5 flex-shrink-0" />
+        <p className="text-sm text-indigo-300/80">
+          Not configured? The system default provider will be used
+          automatically.
+        </p>
+      </div>
+
+      {/* Content */}
+      {isLoading ? (
+        <div className="flex flex-col items-center justify-center py-20">
+          <Loader2 className="w-8 h-8 text-indigo-400 animate-spin" />
+          <p className="text-sm text-gray-500 mt-3">Loading providers...</p>
+        </div>
+      ) : isError ? (
+        <div className="flex flex-col items-center justify-center py-20">
+          <AlertCircle className="w-8 h-8 text-red-400 mb-3" />
+          <p className="text-sm text-red-400">
+            Failed to load providers:{" "}
+            {(error as Error)?.message ?? "Unknown error"}
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          <ProviderCard
+            type="vlm"
+            title="Chat & Extraction (VLM)"
+            description="Vision Language Model for document extraction and chat"
+            currentConfig={data?.vlm ?? null}
+          />
+          <ProviderCard
+            type="embedding"
+            title="Embedding (RAG)"
+            description="Embedding model for knowledge base search"
+            currentConfig={data?.embedding ?? null}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,8 +1,9 @@
 import { NavLink, Outlet, Navigate, useLocation } from "react-router-dom";
-import { Key, Book, ArrowLeft, User, Palette, Info } from "lucide-react";
+import { Key, Book, ArrowLeft, User, Palette, Info, Cpu } from "lucide-react";
 
 const SIDEBAR_ITEMS = [
   { to: "/settings/api-keys", label: "API Keys", icon: Key },
+  { to: "/settings/ai-providers", label: "AI Providers", icon: Cpu },
   { to: "/settings/api-reference", label: "API Reference", icon: Book },
   { to: "/settings/profile", label: "Profile", icon: User },
   { to: "/settings/preferences", label: "Preferences", icon: Palette },

--- a/frontend/src/types/provider.ts
+++ b/frontend/src/types/provider.ts
@@ -1,0 +1,37 @@
+export type ProviderType = "vlm" | "embedding";
+export type ProviderName = "dashscope" | "openai" | "google" | "ollama";
+
+export interface SetProviderRequest {
+  provider_name: ProviderName;
+  api_key: string;
+  model_name: string;
+  base_url?: string | null;
+}
+
+export interface ValidateProviderRequest {
+  provider_name: ProviderName;
+  api_key: string;
+  base_url?: string | null;
+}
+
+export interface ValidateProviderResponse {
+  success: boolean;
+  models: string[];
+  error?: string | null;
+}
+
+export interface ProviderConfigResponse {
+  provider_type: ProviderType;
+  provider_name: ProviderName;
+  model_name: string;
+  base_url: string | null;
+  is_validated: boolean;
+  api_key_prefix: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProvidersResponse {
+  vlm: ProviderConfigResponse | null;
+  embedding: ProviderConfigResponse | null;
+}


### PR DESCRIPTION
## Summary

Users can configure their own API keys for VLM (chat/extraction) and embedding (RAG) providers. Each user picks a provider, enters their key, tests the connection, selects a model from the provider's available list, and saves.

### Backend (24 files, 1955 lines)
- **Encryption**: Fernet encrypt/decrypt for API keys at rest
- **ORM**: `UserProviderConfig` with `UNIQUE(user_id, provider_type)`
- **Settings module**: 6 endpoints (GET configs, PUT vlm/embedding, DELETE vlm/embedding, POST test)
- **Provider testing**: Validates key + returns available models per provider
- **Factory**: `UserProviderOverride` for per-user provider resolution
- **29 new tests** (encryption roundtrip, service validation, usecase CRUD)

### Frontend (4 new files, 3 modified)
- **AI Providers page**: Two cards (VLM + Embedding)
- **Test Connection flow**: Enter key → test → select model → save
- **Configured view**: Shows provider, model, key prefix, update time
- **Remove**: Confirmation dialog, reverts to system default

## Test plan
- [x] 592 backend tests passing
- [x] Frontend production build clean
- [x] Encryption: roundtrip, different ciphertexts, empty string, missing key
- [x] Provider test: mocked DashScope/OpenAI/Google/Ollama validation + model list
- [x] Usecase: get/set/delete providers, test delegation

🤖 Generated with [Claude Code](https://claude.com/claude-code)