### PR TITLE
ci: fix npm install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: 22
 
-      - run: npm ci
+      - run: npm install --no-fund --no-audit
 
       - name: Run semantic-release
         id: semantic


### PR DESCRIPTION
Use npm install instead of npm ci since package-lock.json is in .gitignore