### PR TITLE
fix(projects): true deletion on document remove + RAG orphan defense #104

### DIFF
--- a/backend/alembic/versions/f7a8b9c0d1e2_cascade_chunk_embedding_document_fk.py
+++ b/backend/alembic/versions/f7a8b9c0d1e2_cascade_chunk_embedding_document_fk.py
@@ -1,0 +1,74 @@
+"""Add ON DELETE CASCADE on chunk_embeddings.document_id FK (issue #104).
+
+When a Document is deleted, orphaned ChunkEmbedding rows previously remained
+in the database and leaked into RAG retrieval. This migration alters the FK
+so deletions cascade automatically as defense-in-depth on top of the
+application-layer deletion logic.
+
+Revision ID: f7a8b9c0d1e2
+Revises: e6f7a8b9c0d1
+Create Date: 2026-04-19
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f7a8b9c0d1e2"
+down_revision: Union[str, None] = "e6f7a8b9c0d1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+CONSTRAINT_NAME = "chunk_embeddings_document_id_fkey"
+
+
+def upgrade() -> None:
+    # Drop any existing FK on document_id regardless of its auto-generated
+    # name, so the migration is safe across databases initialised via
+    # `alembic upgrade` or `create_all`.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            existing_name text;
+        BEGIN
+            SELECT conname INTO existing_name
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY (c.conkey)
+            WHERE t.relname = 'chunk_embeddings'
+              AND a.attname = 'document_id'
+              AND c.contype = 'f'
+            LIMIT 1;
+
+            IF existing_name IS NOT NULL THEN
+                EXECUTE format(
+                    'ALTER TABLE chunk_embeddings DROP CONSTRAINT %I',
+                    existing_name
+                );
+            END IF;
+        END $$;
+        """
+    )
+    op.create_foreign_key(
+        CONSTRAINT_NAME,
+        "chunk_embeddings",
+        "documents",
+        ["document_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"ALTER TABLE chunk_embeddings DROP CONSTRAINT IF EXISTS {CONSTRAINT_NAME}"
+    )
+    op.create_foreign_key(
+        CONSTRAINT_NAME,
+        "chunk_embeddings",
+        "documents",
+        ["document_id"],
+        ["id"],
+    )

--- a/backend/src/docmind/dbase/psql/models/chunk_embedding.py
+++ b/backend/src/docmind/dbase/psql/models/chunk_embedding.py
@@ -37,7 +37,10 @@ class ChunkEmbedding(Base):
         String(36), ForeignKey("page_chunks.id", ondelete="CASCADE"), nullable=False
     )
     document_id: Mapped[str] = mapped_column(
-        String(36), ForeignKey("documents.id"), nullable=False, index=True
+        String(36),
+        ForeignKey("documents.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
     )
     provider_name: Mapped[str] = mapped_column(String(50), nullable=False)
     model_name: Mapped[str] = mapped_column(String(100), nullable=False)

--- a/backend/src/docmind/library/rag/retriever.py
+++ b/backend/src/docmind/library/rag/retriever.py
@@ -21,7 +21,7 @@ from sqlalchemy import select
 
 from docmind.core.config import get_settings
 from docmind.dbase.psql.core.session import AsyncSessionLocal
-from docmind.dbase.psql.models import ChunkEmbedding, PageChunk
+from docmind.dbase.psql.models import ChunkEmbedding, Document, PageChunk
 
 logger = logging.getLogger(__name__)
 
@@ -96,9 +96,11 @@ async def _retrieve_vector_only(
         Sorted list of chunk dicts.
     """
     async with AsyncSessionLocal() as session:
+        # JOIN documents to exclude orphaned chunks from deleted docs (issue #104).
         stmt = (
             select(PageChunk, ChunkEmbedding.embedding)
             .join(ChunkEmbedding, ChunkEmbedding.chunk_id == PageChunk.id)
+            .join(Document, Document.id == PageChunk.document_id)
             .where(
                 PageChunk.project_id == project_id,
                 ChunkEmbedding.model_name == model_name,
@@ -164,11 +166,13 @@ async def _retrieve_hybrid(
     bm25_weight = settings.RAG_BM25_WEIGHT
     retrieval_k = settings.RAG_RETRIEVAL_K
 
-    # 1. Get all chunks for this project with embeddings for the model
+    # 1. Get all chunks for this project with embeddings for the model.
+    # JOIN documents to exclude orphaned chunks from deleted docs (issue #104).
     async with AsyncSessionLocal() as session:
         stmt = (
             select(PageChunk, ChunkEmbedding.embedding)
             .join(ChunkEmbedding, ChunkEmbedding.chunk_id == PageChunk.id)
+            .join(Document, Document.id == PageChunk.document_id)
             .where(
                 PageChunk.project_id == project_id,
                 ChunkEmbedding.model_name == model_name,

--- a/backend/src/docmind/modules/analytics/repositories.py
+++ b/backend/src/docmind/modules/analytics/repositories.py
@@ -64,9 +64,17 @@ class AnalyticsRepository:
             return result.scalar() or 0
 
     async def count_chunks(self, user_id: str) -> int:
+        """Count RAG chunks for a user's projects.
+
+        JOINs Document so orphaned chunks from deleted documents are not
+        counted (defense-in-depth for issue #104).
+        """
         async with AsyncSessionLocal() as session:
             result = await session.execute(
-                select(func.count()).select_from(PageChunk).where(
+                select(func.count())
+                .select_from(PageChunk)
+                .join(Document, Document.id == PageChunk.document_id)
+                .where(
                     PageChunk.project_id.in_(
                         select(Project.id).where(Project.user_id == user_id)
                     )

--- a/backend/src/docmind/modules/projects/protocols.py
+++ b/backend/src/docmind/modules/projects/protocols.py
@@ -50,7 +50,7 @@ class ProjectRepositoryProtocol(Protocol):
 
     async def remove_document(
         self, project_id: str, document_id: str
-    ) -> bool: ...
+    ) -> str | None: ...
 
     async def get_document_count(
         self, project_id: str

--- a/backend/src/docmind/modules/projects/repositories/project.py
+++ b/backend/src/docmind/modules/projects/repositories/project.py
@@ -8,7 +8,12 @@ from sqlalchemy import func, select, update
 from docmind.core.logging import get_logger
 from docmind.dbase.psql.core.session import AsyncSessionLocal
 from docmind.dbase.psql.models import (
+    AuditEntry,
+    ChatMessage,
+    Citation,
     Document,
+    ExtractedField,
+    Extraction,
     PageChunk,
     Project,
     ProjectConversation,
@@ -148,6 +153,15 @@ class ProjectRepository:
                     )
                 )
 
+                # Delete all RAG chunks for this project (issue #104).
+                # ChunkEmbedding cascades via PageChunk.id FK.
+                # Documents themselves remain, becoming standalone.
+                await session.execute(
+                    sa_delete(PageChunk).where(
+                        PageChunk.project_id == project_id
+                    )
+                )
+
                 await session.execute(
                     update(Document)
                     .where(Document.project_id == project_id)
@@ -158,7 +172,7 @@ class ProjectRepository:
                 await session.commit()
                 return True
             except Exception as e:
-                logger.error("project_delete_failed: %s", e)
+                logger.error("project_delete_failed", project_id=project_id, error=str(e), exc_info=True)
                 await session.rollback()
                 raise
 
@@ -198,23 +212,101 @@ class ProjectRepository:
             result = await session.execute(stmt)
             return list(result.scalars().all())
 
-    async def remove_document(self, project_id: str, document_id: str) -> bool:
-        """Unlink a document from a project. Returns True if updated."""
+    async def remove_document(
+        self, project_id: str, document_id: str
+    ) -> str | None:
+        """Fully delete a document attached to a project (issue #104).
+
+        Removes the Document and all dependent rows (PageChunks,
+        ChunkEmbeddings via CASCADE, Extractions + children, ChatMessages +
+        Citations). Caller is responsible for removing the storage file using
+        the returned storage_path.
+
+        Args:
+            project_id: Project the document must be linked to.
+            document_id: Document to delete.
+
+        Returns:
+            The document's storage_path if deleted; None if the document is
+            not found or not linked to the given project.
+        """
         async with AsyncSessionLocal() as session:
-            stmt = (
-                update(Document)
-                .where(
+            try:
+                doc_stmt = select(Document).where(
                     Document.id == document_id,
                     Document.project_id == project_id,
                 )
-                .values(
-                    project_id=None,
-                    updated_at=datetime.now(timezone.utc),
+                doc_result = await session.execute(doc_stmt)
+                doc = doc_result.scalar_one_or_none()
+                if doc is None:
+                    return None
+
+                storage_path = doc.storage_path
+
+                ext_stmt = select(Extraction.id).where(
+                    Extraction.document_id == document_id
                 )
-            )
-            result = await session.execute(stmt)
-            await session.commit()
-            return result.rowcount > 0  # type: ignore[union-attr]
+                ext_result = await session.execute(ext_stmt)
+                ext_ids = [row[0] for row in ext_result.all()]
+
+                msg_stmt = select(ChatMessage.id).where(
+                    ChatMessage.document_id == document_id
+                )
+                msg_result = await session.execute(msg_stmt)
+                msg_ids = [row[0] for row in msg_result.all()]
+
+                if ext_ids:
+                    await session.execute(
+                        sa_delete(AuditEntry).where(
+                            AuditEntry.extraction_id.in_(ext_ids)
+                        )
+                    )
+                    await session.execute(
+                        sa_delete(ExtractedField).where(
+                            ExtractedField.extraction_id.in_(ext_ids)
+                        )
+                    )
+                    await session.execute(
+                        sa_delete(Extraction).where(
+                            Extraction.document_id == document_id
+                        )
+                    )
+
+                if msg_ids:
+                    await session.execute(
+                        sa_delete(Citation).where(
+                            Citation.message_id.in_(msg_ids)
+                        )
+                    )
+                    await session.execute(
+                        sa_delete(ChatMessage).where(
+                            ChatMessage.document_id == document_id
+                        )
+                    )
+
+                # PageChunks cascade to ChunkEmbedding via ON DELETE CASCADE
+                # (see chunk_embedding.chunk_id FK). ChunkEmbedding.document_id
+                # FK also cascades after the CASCADE migration.
+                await session.execute(
+                    sa_delete(PageChunk).where(
+                        PageChunk.document_id == document_id
+                    )
+                )
+
+                await session.delete(doc)
+                await session.commit()
+
+                return storage_path
+            except Exception as e:
+                logger.error(
+                    "project_remove_document_failed",
+                    project_id=project_id,
+                    document_id=document_id,
+                    error=str(e),
+                    exc_info=True,
+                )
+                await session.rollback()
+                raise
 
     async def get_document_count(self, project_id: str) -> int:
         """Count documents linked to a project."""
@@ -230,17 +322,27 @@ class ProjectRepository:
     async def list_chunks(
         self, project_id: str, document_id: str | None = None, limit: int = 100
     ) -> tuple[list, int]:
-        """List RAG chunks for a project, optionally filtered by document."""
+        """List RAG chunks for a project, optionally filtered by document.
+
+        JOINs Document to exclude orphaned chunks whose document was deleted
+        (defense-in-depth for issue #104).
+        """
         async with AsyncSessionLocal() as session:
             filters = [PageChunk.project_id == project_id]
             if document_id:
                 filters.append(PageChunk.document_id == document_id)
 
-            count_stmt = select(func.count()).select_from(PageChunk).where(*filters)
+            count_stmt = (
+                select(func.count())
+                .select_from(PageChunk)
+                .join(Document, Document.id == PageChunk.document_id)
+                .where(*filters)
+            )
             total = (await session.execute(count_stmt)).scalar() or 0
 
             stmt = (
                 select(PageChunk)
+                .join(Document, Document.id == PageChunk.document_id)
                 .where(*filters)
                 .order_by(PageChunk.page_number, PageChunk.chunk_index)
                 .limit(limit)

--- a/backend/src/docmind/modules/projects/usecases/project_document.py
+++ b/backend/src/docmind/modules/projects/usecases/project_document.py
@@ -117,13 +117,33 @@ class ProjectDocumentUseCase:
     async def remove_document(
         self, user_id: str, project_id: str, document_id: str
     ) -> bool:
-        """Unlink a document from a project."""
+        """Fully delete a document from a project (issue #104).
+
+        Deletes DB rows (Document, PageChunks, ChunkEmbeddings, Extractions,
+        ChatMessages, Citations) in a single transaction, then removes the
+        storage file. Storage errors are logged but do not fail the operation —
+        the DB is the source of truth.
+        """
         project = await self.repo.get_by_id(project_id, user_id)
         if project is None:
             raise NotFoundException("Project not found")
-        removed = await self.repo.remove_document(project_id, document_id)
-        if not removed:
+        storage_path = await self.repo.remove_document(project_id, document_id)
+        if storage_path is None:
             raise NotFoundException("Document not found in project")
+
+        try:
+            await asyncio.to_thread(
+                self.storage_service.delete_storage_file, storage_path
+            )
+        except Exception as e:
+            logger.warning(
+                "storage_file_delete_failed",
+                storage_path=storage_path,
+                document_id=document_id,
+                error=str(e),
+                exc_info=True,
+            )
+
         return True
 
     async def reindex_document(

--- a/backend/tests/unit/library/rag/test_retriever.py
+++ b/backend/tests/unit/library/rag/test_retriever.py
@@ -143,3 +143,80 @@ class TestRetrieveSimilarChunks:
         )
 
         assert results == []
+
+
+class TestRetrieveJoinsDocument:
+    """Verify retriever JOINs Document table so orphaned chunks are excluded.
+
+    Issue #104: Deleted documents can leave orphaned PageChunk rows. Retrieval
+    MUST JOIN Document to filter them out as defense-in-depth.
+    """
+
+    @pytest.mark.asyncio
+    @patch("docmind.library.rag.retriever.AsyncSessionLocal")
+    async def test_vector_retrieval_joins_documents(self, mock_session_cls):
+        """Vector-only retrieval must include Document in its JOIN chain."""
+        from docmind.library.rag.retriever import _retrieve_vector_only
+
+        executed_stmts: list[object] = []
+
+        async def capture_execute(stmt):
+            executed_stmts.append(stmt)
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        mock_session = AsyncMock()
+        mock_session.execute = capture_execute
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session_cls.return_value = mock_session
+
+        await _retrieve_vector_only(
+            query_embedding=[1.0, 0.0],
+            project_id="proj-x",
+            model_name="test-model",
+            top_k=5,
+            threshold=0.7,
+        )
+
+        assert executed_stmts, "No SQL statement was executed"
+        compiled = str(executed_stmts[0].compile())
+        assert "documents" in compiled.lower(), (
+            f"Expected JOIN with documents table. Got:\n{compiled}"
+        )
+
+    @pytest.mark.asyncio
+    @patch("docmind.library.rag.retriever.AsyncSessionLocal")
+    async def test_hybrid_retrieval_joins_documents(self, mock_session_cls):
+        """Hybrid retrieval must also include Document in its JOIN chain."""
+        from docmind.library.rag.retriever import _retrieve_hybrid
+
+        executed_stmts: list[object] = []
+
+        async def capture_execute(stmt):
+            executed_stmts.append(stmt)
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        mock_session = AsyncMock()
+        mock_session.execute = capture_execute
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session_cls.return_value = mock_session
+
+        await _retrieve_hybrid(
+            query_embedding=[1.0, 0.0],
+            project_id="proj-x",
+            model_name="test-model",
+            query_text="some query",
+            top_k=5,
+            threshold=0.7,
+        )
+
+        assert executed_stmts, "No SQL statement was executed"
+        compiled = str(executed_stmts[0].compile())
+        assert "documents" in compiled.lower(), (
+            f"Expected JOIN with documents table. Got:\n{compiled}"
+        )

--- a/backend/tests/unit/modules/projects/test_repositories.py
+++ b/backend/tests/unit/modules/projects/test_repositories.py
@@ -330,12 +330,12 @@ class TestProjectDelete:
         select_result = MagicMock()
         select_result.scalar_one_or_none.return_value = project
 
-        # SELECT project, SELECT conv_ids (empty), DELETE convs, UPDATE docs unlink, DELETE project
+        # SELECT project, SELECT conv_ids (empty), DELETE convs, DELETE page_chunks, UPDATE docs unlink
         conv_result = MagicMock()
         conv_result.all.return_value = []
 
         session.execute = AsyncMock(
-            side_effect=[select_result, conv_result, MagicMock(), MagicMock()]
+            side_effect=[select_result, conv_result, MagicMock(), MagicMock(), MagicMock()]
         )
         session.delete = AsyncMock()
         session.commit = AsyncMock()
@@ -433,35 +433,176 @@ class TestProjectAddDocument:
 
 
 class TestProjectRemoveDocument:
-    """Tests for ProjectRepository.remove_document()."""
+    """Tests for ProjectRepository.remove_document() — now performs TRUE DELETE.
+
+    As of issue #104, removing a document from a project fully deletes it:
+    - PageChunk + ChunkEmbedding rows
+    - Document row and cascaded extraction/chat data
+    - Caller handles storage file deletion separately
+    """
 
     @pytest.mark.asyncio
     @patch("docmind.modules.projects.repositories.project.AsyncSessionLocal")
-    async def test_returns_true_when_unlinked(self, mock_factory, repo):
+    async def test_returns_storage_path_when_deleted(self, mock_factory, repo):
+        """remove_document returns the storage_path on successful deletion."""
+        doc = _make_document(doc_id=DOC_ID, project_id=PROJECT_ID)
         session = AsyncMock()
-        update_result = MagicMock()
-        update_result.rowcount = 1
-        session.execute = AsyncMock(return_value=update_result)
+
+        doc_result = MagicMock()
+        doc_result.scalar_one_or_none.return_value = doc
+
+        # Extraction/message id queries return empty
+        empty_result = MagicMock()
+        empty_result.all.return_value = []
+
+        # delete() for children
+        delete_result = MagicMock()
+
+        session.execute = AsyncMock(
+            side_effect=[doc_result, empty_result, empty_result, delete_result, delete_result]
+        )
+        session.delete = AsyncMock()
         session.commit = AsyncMock()
         mock_factory.return_value = _mock_session_ctx(session)
 
         result = await repo.remove_document(PROJECT_ID, DOC_ID)
 
-        assert result is True
+        assert result == doc.storage_path
+        session.delete.assert_awaited_once_with(doc)
+        session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
     @patch("docmind.modules.projects.repositories.project.AsyncSessionLocal")
-    async def test_returns_false_when_not_linked(self, mock_factory, repo):
+    async def test_returns_none_when_doc_not_in_project(self, mock_factory, repo):
+        """remove_document returns None if document is not linked to this project."""
         session = AsyncMock()
-        update_result = MagicMock()
-        update_result.rowcount = 0
-        session.execute = AsyncMock(return_value=update_result)
+        doc_result = MagicMock()
+        doc_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=doc_result)
         session.commit = AsyncMock()
         mock_factory.return_value = _mock_session_ctx(session)
 
         result = await repo.remove_document(PROJECT_ID, "nonexistent")
 
-        assert result is False
+        assert result is None
+        session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.projects.repositories.project.AsyncSessionLocal")
+    async def test_deletes_page_chunks_for_document(self, mock_factory, repo):
+        """Chunks for the document must be deleted as part of remove_document."""
+        from sqlalchemy.sql import Delete
+
+        doc = _make_document(doc_id=DOC_ID, project_id=PROJECT_ID)
+        session = AsyncMock()
+
+        doc_result = MagicMock()
+        doc_result.scalar_one_or_none.return_value = doc
+        empty_result = MagicMock()
+        empty_result.all.return_value = []
+        delete_result = MagicMock()
+
+        executed_stmts: list[object] = []
+
+        async def capture_execute(stmt):
+            executed_stmts.append(stmt)
+            if len(executed_stmts) == 1:
+                return doc_result
+            if len(executed_stmts) in (2, 3):
+                return empty_result
+            return delete_result
+
+        session.execute = AsyncMock(side_effect=capture_execute)
+        session.delete = AsyncMock()
+        session.commit = AsyncMock()
+        mock_factory.return_value = _mock_session_ctx(session)
+
+        await repo.remove_document(PROJECT_ID, DOC_ID)
+
+        delete_stmts = [s for s in executed_stmts if isinstance(s, Delete)]
+        chunk_deletes = [
+            s for s in delete_stmts if "page_chunks" in str(s.compile())
+        ]
+        assert len(chunk_deletes) >= 1, (
+            f"Expected delete from page_chunks; executed: {[str(s.compile()) for s in delete_stmts]}"
+        )
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.projects.repositories.project.AsyncSessionLocal")
+    async def test_rolls_back_on_failure(self, mock_factory, repo):
+        """If any delete fails, the transaction rolls back."""
+        doc = _make_document(doc_id=DOC_ID, project_id=PROJECT_ID)
+        session = AsyncMock()
+
+        doc_result = MagicMock()
+        doc_result.scalar_one_or_none.return_value = doc
+
+        session.execute = AsyncMock(side_effect=[doc_result, RuntimeError("DB error")])
+        session.rollback = AsyncMock()
+        session.commit = AsyncMock()
+        mock_factory.return_value = _mock_session_ctx(session)
+
+        with pytest.raises(RuntimeError, match="DB error"):
+            await repo.remove_document(PROJECT_ID, DOC_ID)
+
+        session.rollback.assert_awaited_once()
+        session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("docmind.modules.projects.repositories.project.AsyncSessionLocal")
+    async def test_deletes_extraction_and_chat_children(self, mock_factory, repo):
+        """With existing extractions and chat messages, all child rows are deleted."""
+        from sqlalchemy.sql import Delete
+
+        doc = _make_document(doc_id=DOC_ID, project_id=PROJECT_ID)
+        session = AsyncMock()
+
+        doc_result = MagicMock()
+        doc_result.scalar_one_or_none.return_value = doc
+
+        ext_result = MagicMock()
+        ext_result.all.return_value = [("ext-1",), ("ext-2",)]
+
+        msg_result = MagicMock()
+        msg_result.all.return_value = [("msg-1",), ("msg-2",)]
+
+        delete_result = MagicMock()
+        executed: list[object] = []
+
+        async def capture(stmt):
+            executed.append(stmt)
+            if len(executed) == 1:
+                return doc_result
+            if len(executed) == 2:
+                return ext_result
+            if len(executed) == 3:
+                return msg_result
+            return delete_result
+
+        session.execute = AsyncMock(side_effect=capture)
+        session.delete = AsyncMock()
+        session.commit = AsyncMock()
+        mock_factory.return_value = _mock_session_ctx(session)
+
+        await repo.remove_document(PROJECT_ID, DOC_ID)
+
+        delete_stmts = [s for s in executed if isinstance(s, Delete)]
+        tables = [s.table.name for s in delete_stmts]
+
+        # All child tables must be covered.
+        for expected in (
+            "audit_entries",
+            "extracted_fields",
+            "extractions",
+            "citations",
+            "chat_messages",
+            "page_chunks",
+        ):
+            assert expected in tables, (
+                f"Expected delete from {expected}; got {tables}"
+            )
+        session.delete.assert_awaited_once_with(doc)
+        session.commit.assert_awaited_once()
 
 
 class TestProjectListDocuments:

--- a/backend/tests/unit/modules/projects/test_usecase.py
+++ b/backend/tests/unit/modules/projects/test_usecase.py
@@ -298,6 +298,59 @@ class TestAddDocument:
 
 
 # ---------------------------------------------------------------------------
+# Tests: remove_document (TRUE DELETE per issue #104)
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveDocument:
+    """remove_document now performs full deletion: DB rows + storage file."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_document_and_storage(self, doc_usecase, mock_repo):
+        mock_repo.get_by_id.return_value = _make_project()
+        mock_repo.remove_document.return_value = "documents/user/doc/file.pdf"
+
+        result = await doc_usecase.remove_document(USER_ID, PROJECT_ID, DOC_ID)
+
+        assert result is True
+        mock_repo.remove_document.assert_awaited_once_with(PROJECT_ID, DOC_ID)
+        doc_usecase.storage_service.delete_storage_file.assert_called_once_with(
+            "documents/user/doc/file.pdf"
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_when_project_not_found(self, doc_usecase, mock_repo):
+        mock_repo.get_by_id.return_value = None
+
+        with pytest.raises(NotFoundException):
+            await doc_usecase.remove_document(USER_ID, "nonexistent", DOC_ID)
+
+    @pytest.mark.asyncio
+    async def test_raises_when_doc_not_in_project(self, doc_usecase, mock_repo):
+        mock_repo.get_by_id.return_value = _make_project()
+        mock_repo.remove_document.return_value = None
+
+        with pytest.raises(NotFoundException):
+            await doc_usecase.remove_document(USER_ID, PROJECT_ID, "nonexistent")
+        doc_usecase.storage_service.delete_storage_file.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_storage_delete_failure_does_not_raise(
+        self, doc_usecase, mock_repo
+    ):
+        """Storage failures are logged but do not fail the operation — DB is source of truth."""
+        mock_repo.get_by_id.return_value = _make_project()
+        mock_repo.remove_document.return_value = "documents/user/doc/file.pdf"
+        doc_usecase.storage_service.delete_storage_file.side_effect = RuntimeError(
+            "Storage offline"
+        )
+
+        result = await doc_usecase.remove_document(USER_ID, PROJECT_ID, DOC_ID)
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
 # Tests: list_documents
 # ---------------------------------------------------------------------------
 

--- a/frontend/src/components/project/ProjectDocumentsPanel.tsx
+++ b/frontend/src/components/project/ProjectDocumentsPanel.tsx
@@ -207,7 +207,10 @@ export function ProjectDocumentsPanel({ projectId, onDocumentClick }: Props) {
                 index={i}
                 onClick={() => onDocumentClick?.(doc)}
                 onReindex={() => handleReindex(doc.id, doc.filename)}
-                onRemove={() => { if (window.confirm(`Remove "${doc.filename}"?`)) removeDoc.mutate(doc.id); }}
+                onRemove={() => {
+                  const msg = `Delete "${doc.filename}"?\n\nThis permanently removes the document, its extracted data, and all indexed chunks. This cannot be undone.`;
+                  if (window.confirm(msg)) removeDoc.mutate(doc.id);
+                }}
               />
             ))}
           </div>
@@ -343,11 +346,11 @@ function CompactDocRow({
           <Database className="w-3.5 h-3.5" />
         </button>
 
-        {/* Remove — visible on hover */}
+        {/* Delete — visible on hover */}
         <button
           onClick={(e) => { e.stopPropagation(); onRemove(); }}
           className="p-1 text-gray-600 hover:text-rose-400 rounded transition-colors opacity-0 group-hover:opacity-100"
-          title="Remove from project"
+          title="Delete document permanently"
         >
           <Trash2 className="w-3.5 h-3.5" />
         </button>

--- a/frontend/src/components/project/ProjectDocumentsTab.tsx
+++ b/frontend/src/components/project/ProjectDocumentsTab.tsx
@@ -201,7 +201,10 @@ export function ProjectDocumentsTab({ projectId }: Props) {
                   doc={doc}
                   index={i}
                   onReindex={() => handleReindex(doc.id, doc.filename)}
-                  onRemove={() => { if (window.confirm(`Remove "${doc.filename}"?`)) removeDoc.mutate(doc.id); }}
+                  onRemove={() => {
+                    const msg = `Delete "${doc.filename}"?\n\nThis permanently removes the document, its extracted data, and all indexed chunks. This cannot be undone.`;
+                    if (window.confirm(msg)) removeDoc.mutate(doc.id);
+                  }}
                 />
               ))}
 
@@ -392,7 +395,7 @@ function DocumentRow({
                 className="w-full flex items-center gap-2 px-3 py-2 text-[12px] text-rose-400 hover:bg-rose-500/[0.06] transition-colors"
               >
                 <Trash2 className="w-3.5 h-3.5" />
-                Remove
+                Delete
               </button>
             </div>
           </>

--- a/frontend/src/components/project/ProjectSidebar.tsx
+++ b/frontend/src/components/project/ProjectSidebar.tsx
@@ -142,7 +142,8 @@ export function ProjectSidebar({ projectId, activeConvId, onSelectConversation, 
   );
 
   const handleRemoveDoc = (docId: string, filename: string) => {
-    if (window.confirm(`Remove "${filename}" from this project?`)) {
+    const msg = `Delete "${filename}"?\n\nThis permanently removes the document, its extracted data, and all indexed chunks. This cannot be undone.`;
+    if (window.confirm(msg)) {
       removeDoc.mutate(docId);
     }
   };

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -103,12 +103,15 @@ export function useRemoveProjectDocument(projectId: string) {
   return useMutation({
     mutationFn: (docId: string) => removeProjectDocument(projectId, docId),
     onSuccess: () => {
-      toast.success("Document removed from project");
+      toast.success("Document deleted");
       qc.invalidateQueries({ queryKey: ["project-documents", projectId] });
+      qc.invalidateQueries({ queryKey: ["project-chunks", projectId] });
       qc.invalidateQueries({ queryKey: ["projects"] });
+      qc.invalidateQueries({ queryKey: ["documents"] });
+      qc.invalidateQueries({ queryKey: ["analytics"] });
     },
     onError: (error: Error) => {
-      toast.error(`Remove failed: ${error.message}`);
+      toast.error(`Delete failed: ${error.message}`);
     },
   });
 }


### PR DESCRIPTION
## Summary

Fixes data-leakage bug reported by stakeholder for the Kemendagri demo: documents "deleted" from a project were only unlinked (`Document.project_id = NULL`), leaving `PageChunk` and `ChunkEmbedding` rows attached to the project so the AI kept answering from deleted documents.

Resolves #104.

### Backend
- `ProjectRepository.remove_document` now fully deletes the `Document` + all child rows (PageChunks, ChunkEmbeddings via cascade, Extractions, Chat Messages, Citations) in one transaction and returns `storage_path`.
- `ProjectRepository.delete` also deletes PageChunks before unlinking docs so project deletion cannot leave orphans.
- `ProjectDocumentUseCase.remove_document` deletes the Supabase Storage file through `asyncio.to_thread`; storage errors are logged but non-fatal.
- Added `ondelete=CASCADE` on `chunk_embeddings.document_id` with a safe migration that drops the existing auto-named constraint regardless of its original name.
- RAG retriever (`_retrieve_vector_only`, `_retrieve_hybrid`) JOINs `documents`. Defense-in-depth in `analytics.count_chunks` and `project.list_chunks`.

### Frontend
- Action renamed "Remove from project" → **"Delete document permanently"** across `ProjectDocumentsPanel`, `ProjectSidebar`, `ProjectDocumentsTab` with clear confirmation.
- `useRemoveProjectDocument` invalidates: `project-documents`, `project-chunks`, `projects`, `documents`, `analytics`.

## Test plan
- [x] 618 unit tests pass (4 new + 1 updated + 0 regressions)
- [x] TypeScript build clean
- [ ] Run `alembic upgrade head` on staging DB
- [ ] Manual reproduce: upload 2 docs → delete → upload 2 → verify RAG sees only new 2
- [ ] Manual: delete a project containing indexed docs → verify chunks gone

## Files Changed
- `backend/src/docmind/modules/projects/repositories/project.py`
- `backend/src/docmind/modules/projects/usecases/project_document.py`
- `backend/src/docmind/modules/projects/protocols.py`
- `backend/src/docmind/dbase/psql/models/chunk_embedding.py`
- `backend/alembic/versions/f7a8b9c0d1e2_cascade_chunk_embedding_document_fk.py` (new)
- `backend/src/docmind/library/rag/retriever.py`
- `backend/src/docmind/modules/analytics/repositories.py`
- `frontend/src/components/project/ProjectDocumentsPanel.tsx`
- `frontend/src/components/project/ProjectDocumentsTab.tsx`
- `frontend/src/components/project/ProjectSidebar.tsx`
- `frontend/src/hooks/useProjects.ts`
- Tests: `test_repositories.py`, `test_usecase.py`, `test_retriever.py`