### PR TITLE
feat(rag): strict grounding, retrieval diversity, language-aware refusal #105

### DIFF
--- a/backend/src/docmind/core/config.py
+++ b/backend/src/docmind/core/config.py
@@ -111,9 +111,13 @@ class Settings(BaseSettings):
     EMBEDDING_DIMENSIONS: int = Field(default=1024)
     RAG_CHUNK_SIZE: int = Field(default=1200)
     RAG_CHUNK_OVERLAP: int = Field(default=200)
-    RAG_TOP_K: int = Field(default=5)
-    RAG_RETRIEVAL_K: int = Field(default=20)
+    RAG_TOP_K: int = Field(default=10)
+    RAG_RETRIEVAL_K: int = Field(default=30)
     RAG_SIMILARITY_THRESHOLD: float = Field(default=0.1)
+    # Issue #105: if max similarity across retrieved chunks falls below this,
+    # the chat pipeline refuses with a grounded "I don't know" instead of
+    # calling the VLM with weak context.
+    RAG_REFUSAL_THRESHOLD: float = Field(default=0.25)
     RAG_BM25_WEIGHT: float = Field(default=0.4)
     RAG_VECTOR_WEIGHT: float = Field(default=0.6)
     RAG_BM25_LANGUAGE: str = Field(default="simple")

--- a/backend/src/docmind/library/rag/retriever.py
+++ b/backend/src/docmind/library/rag/retriever.py
@@ -74,6 +74,55 @@ async def retrieve_similar_chunks(
     )
 
 
+async def retrieve_similar_chunks_with_stats(
+    query_embedding: list[float],
+    project_id: str,
+    model_name: str,
+    top_k: int | None = None,
+    threshold: float | None = None,
+    query_text: str = "",
+) -> dict:
+    """Retrieve chunks plus diagnostic stats (issue #105).
+
+    Same retrieval as `retrieve_similar_chunks` but also returns aggregate
+    statistics that callers (e.g. project chat) use to decide whether to
+    refuse before calling the VLM.
+
+    Returns:
+        dict with keys:
+            chunks: list[dict] — retrieved chunks (already diversified + capped).
+            max_similarity: float — highest similarity across retrieved chunks (0.0 if empty).
+            per_document_counts: dict[str, int] — chunks per document_id.
+    """
+    chunks = await retrieve_similar_chunks(
+        query_embedding=query_embedding,
+        project_id=project_id,
+        model_name=model_name,
+        top_k=top_k,
+        threshold=threshold,
+        query_text=query_text,
+    )
+
+    if not chunks:
+        return {
+            "chunks": [],
+            "max_similarity": 0.0,
+            "per_document_counts": {},
+        }
+
+    max_sim = max(c.get("similarity", 0.0) for c in chunks)
+    counts: dict[str, int] = {}
+    for c in chunks:
+        doc_id = c.get("document_id", "")
+        counts[doc_id] = counts.get(doc_id, 0) + 1
+
+    return {
+        "chunks": chunks,
+        "max_similarity": max_sim,
+        "per_document_counts": counts,
+    }
+
+
 async def _retrieve_vector_only(
     query_embedding: list[float],
     project_id: str,
@@ -131,7 +180,9 @@ async def _retrieve_vector_only(
             })
 
     scored.sort(key=lambda x: x["similarity"], reverse=True)
-    return scored[:top_k]
+    # Apply per-document diversity so a single document cannot monopolise
+    # the top-K (issue #105).
+    return _diversify_results(scored, top_k)
 
 
 async def _retrieve_hybrid(
@@ -263,34 +314,38 @@ async def _retrieve_hybrid(
 def _diversify_results(results: list[dict], top_k: int) -> list[dict]:
     """Diversify results to include chunks from different documents.
 
-    Uses a round-robin strategy: pick the best chunk from each document
-    first, then fill remaining slots with next-best chunks.
+    Round-robin strategy: pick the best chunk from each document, then the
+    second best, etc. GUARANTEES at least one chunk per document as long as
+    that document contributed any chunk (issue #105). Preserves relative
+    ordering within each document's chunks.
+
+    If there are fewer results than top_k, still round-robins so that the
+    order promotes diversity rather than concentration.
 
     Args:
-        results: Sorted list of chunk dicts (best first).
+        results: Sorted list of chunk dicts (best first) with a
+            ``document_id`` key on each chunk.
         top_k: Maximum results to return.
 
     Returns:
-        Diversified list of chunk dicts, up to top_k.
+        Diversified list of chunk dicts, up to top_k, preserving the
+        relative order within each document.
     """
-    if len(results) <= top_k:
-        return results
+    if not results:
+        return []
 
-    # Group by document
+    # Preserve document insertion order (= global similarity order) so
+    # the strongest document wins the first round-robin slot.
     doc_buckets: dict[str, list[dict]] = {}
     for r in results:
-        doc_id = r["document_id"]
-        if doc_id not in doc_buckets:
-            doc_buckets[doc_id] = []
-        doc_buckets[doc_id].append(r)
+        doc_buckets.setdefault(r["document_id"], []).append(r)
 
-    # Round-robin: pick best from each doc, then second-best, etc.
     diversified: list[dict] = []
     seen_ids: set[str] = set()
-    max_rounds = top_k
+    max_rounds = max(len(bucket) for bucket in doc_buckets.values())
 
     for _round in range(max_rounds):
-        for doc_id, chunks in doc_buckets.items():
+        for chunks in doc_buckets.values():
             if _round < len(chunks):
                 chunk = chunks[_round]
                 cid = chunk["chunk_id"]

--- a/backend/src/docmind/modules/projects/protocols.py
+++ b/backend/src/docmind/modules/projects/protocols.py
@@ -100,19 +100,25 @@ class ConversationRepositoryProtocol(Protocol):
 
 
 class PromptServiceProtocol(Protocol):
-    """Contract for prompt building."""
+    """Contract for project prompt building.
+
+    Signatures match ``ProjectPromptService`` in services/prompt.py.
+    """
 
     def build_system_prompt(
         self,
-        persona_name: str,
-        persona_prompt: str,
-        context: str,
-        citations: list,
+        persona: dict | None,
+        doc_metadata: str,
+        doc_count: int,
     ) -> str: ...
 
-    def format_context(
-        self, chunks: list[dict], citations: list
-    ) -> str: ...
+    def build_rag_context(
+        self, chunks: list[dict]
+    ) -> tuple[str, list[dict]]: ...
+
+    def format_document_metadata(self, docs: list) -> str: ...
+
+    def validate_project_name(self, name: str) -> str: ...
 
     def validate_persona_assignment(
         self, persona_id: str | None
@@ -130,6 +136,13 @@ class RAGServiceProtocol(Protocol):
         query_embedding: list[float],
         query_text: str,
     ) -> list[dict]: ...
+
+    def retrieve_chunks_with_stats(
+        self,
+        project_id: str,
+        query_embedding: list[float],
+        query_text: str,
+    ) -> dict: ...
 
     def rewrite_query(
         self, message: str, history: list[dict]

--- a/backend/src/docmind/modules/projects/services/prompt.py
+++ b/backend/src/docmind/modules/projects/services/prompt.py
@@ -1,5 +1,45 @@
 """Project prompt service — builds prompts and formats context for RAG chat."""
 
+# Stopword-light language heuristic — we only need to pick Indonesian vs English
+# for refusal text. Covers common connectors / question words.
+_INDONESIAN_MARKERS = frozenset(
+    {
+        "yang", "dan", "ini", "itu", "dari", "untuk", "dengan", "adalah",
+        "ada", "apa", "di", "ke", "kamu", "saya", "kita", "kami", "kenapa",
+        "mengapa", "siapa", "kapan", "dimana", "berapa", "bagaimana", "tidak",
+        "tolong", "mohon", "jelaskan", "bagaimanakah", "berasal", "produk",
+        "mana", "dokumen",
+    }
+)
+
+REFUSAL_EN = (
+    "I cannot find that information in the uploaded documents. "
+    "Please rephrase your question or upload additional sources."
+)
+REFUSAL_ID = (
+    "Saya tidak menemukan informasi tersebut dalam dokumen yang diunggah. "
+    "Silakan coba ubah pertanyaan atau unggah dokumen tambahan."
+)
+
+
+def detect_language(text: str) -> str:
+    """Return 'id' if the message is likely Indonesian, else 'en'.
+
+    Deliberately simple — a stopword overlap beats nothing when the LLM would
+    otherwise spend tokens guessing.
+    """
+    if not text:
+        return "en"
+    tokens = {t for t in text.lower().split() if t.isalpha()}
+    if tokens & _INDONESIAN_MARKERS:
+        return "id"
+    return "en"
+
+
+def grounded_refusal(language: str) -> str:
+    """Return a refusal message in the requested language."""
+    return REFUSAL_ID if language == "id" else REFUSAL_EN
+
 
 class ProjectPromptService:
     """Builds prompts and formats context for project RAG chat."""
@@ -38,24 +78,41 @@ class ProjectPromptService:
 
         base += (
             f"\n\nPROJECT DOCUMENTS ({doc_count} files):\n{doc_metadata}"
-            "\n\nIMPORTANT: Base your answers ONLY on the provided context. "
-            "Cite sources using [Source N] notation. "
-            "If the context doesn't contain relevant information, say so clearly. "
-            "When asked about files or documents, refer to the PROJECT DOCUMENTS list above."
-            "\n\nLANGUAGE: Always respond in the same language the user writes in. "
-            "If the user writes in Indonesian, respond in Indonesian. "
-            "If in English, respond in English. Match the user's language exactly."
+            "\n\nIMPORTANT — STRICT GROUNDING:"
+            "\n- Base your answers ONLY on the provided context below."
+            "\n- Cite every factual claim using [Source N] notation matching the"
+            " context indices."
+            "\n- If the context does not contain the answer, explicitly say you"
+            " do not have that information in the uploaded documents — do NOT"
+            " guess or rely on prior knowledge."
+            "\n- When asked about files or documents, refer to the PROJECT"
+            " DOCUMENTS list above."
+            "\n\nMULTI-SOURCE SYNTHESIS:"
+            "\n- When the question spans multiple documents or asks about an"
+            " aggregate (e.g. 'where does this come from?', 'list all…', "
+            "'compare…'), ENUMERATE the answer across ALL relevant sources."
+            "\n- Do not stop at the first matching source — inspect every"
+            " [Source N] block and report findings from each document that"
+            " applies."
+            "\n\nLANGUAGE: Always respond in the same language the user writes in."
+            " If the user writes in Indonesian, respond in Indonesian."
+            " If in English, respond in English. Match the user's language exactly."
         )
         return base
 
     def build_rag_context(self, chunks: list[dict]) -> tuple[str, list[dict]]:
-        """Build context text and citations from retrieved chunks."""
+        """Build context text and citations from retrieved chunks.
+
+        Citations include ``chunk_id`` so the frontend can link directly to
+        the exact retrieved chunk (issue #105).
+        """
         context_parts: list[str] = []
         citations: list[dict] = []
         for i, chunk in enumerate(chunks, 1):
             context_parts.append(f"[Source {i}]: {chunk.get('content', '')}")
             citations.append({
                 "source_index": i,
+                "chunk_id": chunk.get("chunk_id", ""),
                 "document_id": chunk.get("document_id", ""),
                 "page_number": chunk.get("page_number", 0),
                 "content_preview": chunk.get("content", "")[:100],

--- a/backend/src/docmind/modules/projects/services/rag.py
+++ b/backend/src/docmind/modules/projects/services/rag.py
@@ -4,7 +4,10 @@ from docmind.core.config import get_settings
 from docmind.library.providers.factory import UserProviderOverride
 from docmind.library.rag.embedder import embed_texts
 from docmind.library.rag.query_rewriter import rewrite_query_with_context
-from docmind.library.rag.retriever import retrieve_similar_chunks
+from docmind.library.rag.retriever import (
+    retrieve_similar_chunks,
+    retrieve_similar_chunks_with_stats,
+)
 
 
 class ProjectRAGService:
@@ -26,6 +29,25 @@ class ProjectRAGService:
     ) -> list[dict]:
         """Retrieve relevant chunks using hybrid search."""
         return await retrieve_similar_chunks(
+            query_embedding=query_embedding,
+            project_id=project_id,
+            model_name=self._settings.EMBEDDING_MODEL,
+            top_k=self._settings.RAG_TOP_K,
+            threshold=self._settings.RAG_SIMILARITY_THRESHOLD,
+            query_text=query_text,
+        )
+
+    async def retrieve_chunks_with_stats(
+        self,
+        project_id: str,
+        query_embedding: list[float],
+        query_text: str,
+    ) -> dict:
+        """Retrieve chunks plus stats for grounding/refusal decisions.
+
+        Returns dict with ``chunks``, ``max_similarity``, ``per_document_counts``.
+        """
+        return await retrieve_similar_chunks_with_stats(
             query_embedding=query_embedding,
             project_id=project_id,
             model_name=self._settings.EMBEDDING_MODEL,

--- a/backend/src/docmind/modules/projects/usecases/project_chat.py
+++ b/backend/src/docmind/modules/projects/usecases/project_chat.py
@@ -3,9 +3,9 @@
 import json
 from collections.abc import AsyncGenerator
 
+from docmind.core.config import get_settings
 from docmind.core.logging import get_logger
 from docmind.modules.personas.protocols import PersonaRepositoryProtocol
-from docmind.shared.exceptions import NotFoundException
 
 from ..protocols import (
     ConversationRepositoryProtocol,
@@ -20,6 +20,7 @@ from ..services import (
     ProjectRAGService,
     ProjectVLMService,
 )
+from ..services.prompt import detect_language, grounded_refusal
 
 logger = get_logger(__name__)
 
@@ -131,20 +132,59 @@ class ProjectChatUseCase:
             logger.warning("Query rewrite failed: %s", e)
             yield _sse("status", {"message": "Searching documents..."})
 
-        # --- RAG Retrieval (via service) ---
+        # --- RAG Retrieval with stats (via service) ---
+        retrieval_stats: dict = {"max_similarity": 0.0, "per_document_counts": {}}
         try:
             query_embedding = await self.rag_service.embed_query(search_query)
-            chunks = await self.rag_service.retrieve_chunks(
+            retrieval_stats = await self.rag_service.retrieve_chunks_with_stats(
                 project_id=project_id,
                 query_embedding=query_embedding,
                 query_text=search_query,
             )
+            chunks = retrieval_stats["chunks"]
         except Exception as e:
             logger.error("RAG retrieval failed: %s", e)
             chunks = []
 
+        logger.info(
+            "rag_retrieval_diagnostics",
+            project_id=project_id,
+            query_chars=len(search_query),
+            chunk_count=len(chunks),
+            max_similarity=retrieval_stats.get("max_similarity", 0.0),
+            per_document_counts=retrieval_stats.get("per_document_counts", {}),
+        )
+
         # Build context from retrieved chunks (via service)
         context_text, citations = self.prompt_service.build_rag_context(chunks)
+
+        # --- Refusal guard (issue #105) ---
+        # If retrieval produced nothing or similarity is below the refusal
+        # threshold, return a deterministic grounded refusal in the user's
+        # language WITHOUT calling the VLM.
+        refusal_threshold = get_settings().RAG_REFUSAL_THRESHOLD
+        if (
+            not chunks
+            or retrieval_stats.get("max_similarity", 0.0) < refusal_threshold
+        ):
+            language = detect_language(message)
+            refusal_text = grounded_refusal(language)
+            yield _sse("token", {"content": refusal_text})
+            yield _sse(
+                "answer",
+                {
+                    "content": refusal_text,
+                    "citations": [],
+                    "conversation_id": conversation_id,
+                    "refusal": True,
+                    "max_similarity": retrieval_stats.get("max_similarity", 0.0),
+                },
+            )
+            await self.conv_repo.add_message(
+                conversation_id, "assistant", refusal_text, citations=None
+            )
+            yield _sse("done", {"conversation_id": conversation_id})
+            return
 
         # Load document metadata for the system prompt (via service)
         doc_list = await self.repo.list_documents(project_id, user_id)

--- a/backend/tests/unit/library/pipeline/test_chat_grounding.py
+++ b/backend/tests/unit/library/pipeline/test_chat_grounding.py
@@ -1,0 +1,149 @@
+"""Tests for strict grounding in the project RAG prompt service (issue #105).
+
+Demo-critical: system prompts must enforce single-source-of-truth behaviour.
+"""
+
+import pytest
+
+from docmind.modules.projects.services.prompt import ProjectPromptService
+
+
+@pytest.fixture
+def service() -> ProjectPromptService:
+    return ProjectPromptService()
+
+
+class TestGroundingPrompt:
+    """System prompt must enforce strict grounding and synthesis."""
+
+    def test_prompt_demands_answers_only_from_context(self, service):
+        prompt = service.build_system_prompt(
+            persona=None, doc_metadata="- report.pdf", doc_count=1
+        )
+        assert "ONLY" in prompt
+        assert (
+            "context" in prompt.lower()
+            and "answer" in prompt.lower()
+        )
+
+    def test_prompt_requires_explicit_refusal(self, service):
+        prompt = service.build_system_prompt(
+            persona=None, doc_metadata="", doc_count=0
+        )
+        low = prompt.lower()
+        assert (
+            "don't know" in low
+            or "do not know" in low
+            or "cannot" in low
+            or "don't have" in low
+            or "not contain" in low
+        ), f"Prompt must explicitly instruct refusal when context lacks info: {prompt}"
+
+    def test_prompt_requires_synthesis_across_sources(self, service):
+        """When the question spans multiple docs, LLM must enumerate all of them."""
+        prompt = service.build_system_prompt(
+            persona=None,
+            doc_metadata="- report-a.pdf\n- report-b.pdf",
+            doc_count=2,
+        )
+        low = prompt.lower()
+        assert (
+            "all" in low
+            and ("source" in low or "document" in low)
+        ), (
+            "Prompt must instruct the LLM to synthesize across all provided "
+            f"sources. Got: {prompt}"
+        )
+        # Specifically: aggregate/enumeration directive
+        assert (
+            "enumerate" in low
+            or "aggregate" in low
+            or "multiple" in low
+            or "both" in low
+            or "each" in low
+        ), f"Prompt must cover aggregate/multi-doc questions: {prompt}"
+
+    def test_prompt_requires_citations(self, service):
+        prompt = service.build_system_prompt(
+            persona=None, doc_metadata="- doc.pdf", doc_count=1
+        )
+        assert "cite" in prompt.lower() or "citation" in prompt.lower() or "[Source" in prompt
+
+    def test_prompt_language_mirroring_preserved(self, service):
+        """Existing bilingual behaviour must survive the refactor."""
+        prompt = service.build_system_prompt(
+            persona=None, doc_metadata="- doc.pdf", doc_count=1
+        )
+        low = prompt.lower()
+        assert "indonesian" in low or "bahasa" in low
+        assert "english" in low
+        assert "same language" in low or "match" in low
+
+
+class TestLanguageDetectionAndRefusal:
+    """Grounded refusal must respond in the user's language (issue #105)."""
+
+    def test_detects_indonesian(self):
+        from docmind.modules.projects.services.prompt import detect_language
+
+        assert detect_language("Apa yang ada di dokumen ini?") == "id"
+        assert detect_language("Produk ini berasal dari mana?") == "id"
+
+    def test_detects_english(self):
+        from docmind.modules.projects.services.prompt import detect_language
+
+        assert detect_language("Where does this product come from?") == "en"
+        assert detect_language("What is this document about?") == "en"
+
+    def test_refusal_text_in_each_language(self):
+        from docmind.modules.projects.services.prompt import grounded_refusal
+
+        en = grounded_refusal("en")
+        id_ = grounded_refusal("id")
+        assert "cannot find" in en.lower() or "not find" in en.lower()
+        assert "tidak menemukan" in id_.lower()
+
+
+class TestBuildRagContext:
+    """build_rag_context must produce citations and handle empty retrieval."""
+
+    def test_empty_chunks_produces_empty_citations_and_sentinel_context(self, service):
+        context_text, citations = service.build_rag_context([])
+        assert citations == []
+        assert "no relevant" in context_text.lower() or context_text.strip() == ""
+
+    def test_citations_include_required_fields(self, service):
+        chunks = [
+            {
+                "chunk_id": "c1",
+                "document_id": "doc-A",
+                "page_number": 3,
+                "content": "Invoice total is $500.",
+                "similarity": 0.87,
+            }
+        ]
+        _ctx, citations = service.build_rag_context(chunks)
+        assert len(citations) == 1
+        cite = citations[0]
+        for required in (
+            "source_index",
+            "document_id",
+            "page_number",
+            "similarity",
+        ):
+            assert required in cite, f"Citation missing field {required!r}: {cite}"
+        # #105 ask: chunk_id must flow through so future UI can link to a chunk
+        assert cite.get("chunk_id") == "c1", (
+            "Citation must include chunk_id so UI can link to the exact retrieved chunk"
+        )
+
+    def test_multiple_chunks_are_indexed_and_ordered(self, service):
+        chunks = [
+            {"chunk_id": "c1", "document_id": "A", "page_number": 1, "content": "x", "similarity": 0.9},
+            {"chunk_id": "c2", "document_id": "B", "page_number": 2, "content": "y", "similarity": 0.8},
+        ]
+        ctx, citations = service.build_rag_context(chunks)
+        assert "[Source 1]" in ctx
+        assert "[Source 2]" in ctx
+        assert citations[0]["source_index"] == 1
+        assert citations[1]["source_index"] == 2

--- a/backend/tests/unit/library/rag/test_retriever_diversity.py
+++ b/backend/tests/unit/library/rag/test_retriever_diversity.py
@@ -1,0 +1,222 @@
+"""Tests for retrieval diversity (issue #105).
+
+Scenario that motivated this work: a project with 2 documents where one
+document's chunks dominate vector similarity. Without per-document quota
+enforcement, aggregate questions ("where does this come from?") return an
+answer from only one document.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from docmind.library.rag.retriever import _diversify_results
+
+
+def _chunk(
+    chunk_id: str,
+    document_id: str,
+    page: int = 1,
+    similarity: float = 0.9,
+    content: str = "text",
+) -> dict:
+    return {
+        "chunk_id": chunk_id,
+        "document_id": document_id,
+        "page_number": page,
+        "content": content,
+        "raw_content": content,
+        "similarity": similarity,
+    }
+
+
+class TestDiversifyResults:
+    """Direct tests on _diversify_results for per-document fairness."""
+
+    def test_single_document_keeps_order(self):
+        results = [_chunk(f"c{i}", "doc-A", similarity=1.0 - i * 0.1) for i in range(5)]
+        out = _diversify_results(results, top_k=3)
+        assert [c["chunk_id"] for c in out] == ["c0", "c1", "c2"]
+
+    def test_round_robin_across_two_docs_at_top_k_equal_to_one_per_doc(self):
+        """At top_k=2 with two docs, each must appear exactly once."""
+        results = [
+            _chunk("a1", "doc-A", similarity=0.95),
+            _chunk("a2", "doc-A", similarity=0.90),
+            _chunk("a3", "doc-A", similarity=0.80),
+            _chunk("b1", "doc-B", similarity=0.70),
+        ]
+        out = _diversify_results(results, top_k=2)
+        doc_ids = {c["document_id"] for c in out}
+        assert doc_ids == {"doc-A", "doc-B"}, (
+            f"Expected both docs represented, got {doc_ids}"
+        )
+
+    def test_top_k_5_with_two_docs_at_least_one_per_doc(self):
+        """Mas AAN's scenario: top_k=5, doc-A dominates — doc-B must still appear."""
+        results = (
+            [_chunk(f"a{i}", "doc-A", similarity=0.95 - i * 0.01) for i in range(10)]
+            + [_chunk("b1", "doc-B", similarity=0.5)]
+        )
+        out = _diversify_results(results, top_k=5)
+        doc_ids = {c["document_id"] for c in out}
+        assert "doc-B" in doc_ids, (
+            f"Doc B must appear in top-5 even when Doc A has many strong matches; "
+            f"got {doc_ids}"
+        )
+
+    def test_fewer_results_than_top_k_returns_all(self):
+        results = [
+            _chunk("a1", "doc-A", similarity=0.9),
+            _chunk("b1", "doc-B", similarity=0.8),
+        ]
+        out = _diversify_results(results, top_k=10)
+        assert len(out) == 2
+
+    def test_strongest_document_wins_round_zero_slot(self):
+        """The globally best chunk must appear first regardless of its document."""
+        results = [
+            _chunk("b0", "doc-B", similarity=0.99),  # Globally best
+            _chunk("a0", "doc-A", similarity=0.95),
+            _chunk("a1", "doc-A", similarity=0.90),
+            _chunk("b1", "doc-B", similarity=0.80),
+        ]
+        out = _diversify_results(results, top_k=2)
+        assert out[0]["chunk_id"] == "b0", (
+            "Position 0 must be the globally highest-similarity chunk"
+        )
+
+    def test_three_docs_round_robin(self):
+        results = (
+            [_chunk(f"a{i}", "doc-A", similarity=0.9 - i * 0.01) for i in range(3)]
+            + [_chunk(f"b{i}", "doc-B", similarity=0.7 - i * 0.01) for i in range(3)]
+            + [_chunk(f"c{i}", "doc-C", similarity=0.5 - i * 0.01) for i in range(3)]
+        )
+        out = _diversify_results(results, top_k=6)
+        # First 3 should be one from each doc (round 0), then one from each (round 1)
+        first_three_docs = {c["document_id"] for c in out[:3]}
+        assert first_three_docs == {"doc-A", "doc-B", "doc-C"}
+
+
+class TestVectorOnlyDiversifies:
+    """Vector-only retrieval must also diversify (issue #105).
+
+    Previously, _retrieve_vector_only returned top-K by similarity only,
+    so one document could monopolise the results.
+    """
+
+    @pytest.mark.asyncio
+    @patch("docmind.library.rag.retriever.AsyncSessionLocal")
+    async def test_vector_only_returns_both_documents(self, mock_session_cls):
+        from docmind.library.rag.retriever import _retrieve_vector_only
+
+        # doc-A has 4 high-similarity chunks, doc-B has 1 lower chunk
+        chunks: list[tuple[MagicMock, str]] = []
+        for i in range(4):
+            c = MagicMock()
+            c.id = f"a{i}"
+            c.document_id = "doc-A"
+            c.page_number = i + 1
+            c.content = f"Ngaglik content {i}"
+            c.raw_content = f"Ngaglik content {i}"
+            chunks.append((c, json.dumps([1.0 - i * 0.01, 0.0])))
+        b = MagicMock()
+        b.id = "b1"
+        b.document_id = "doc-B"
+        b.page_number = 1
+        b.content = "Other Polsek content"
+        b.raw_content = "Other Polsek content"
+        chunks.append((b, json.dumps([0.8, 0.2])))
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = chunks
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session_cls.return_value = mock_session
+
+        out = await _retrieve_vector_only(
+            query_embedding=[1.0, 0.0],
+            project_id="proj-1",
+            model_name="m",
+            top_k=3,
+            threshold=0.5,
+        )
+
+        doc_ids = {c["document_id"] for c in out}
+        assert "doc-B" in doc_ids, (
+            f"doc-B must appear even when doc-A has many strong matches; got {doc_ids}"
+        )
+
+
+class TestRetrieveSimilarChunksReturnsDiagnostics:
+    """Top-level API should expose max_similarity so refusal logic can act on it."""
+
+    @pytest.mark.asyncio
+    @patch("docmind.library.rag.retriever.AsyncSessionLocal")
+    async def test_retrieve_returns_dict_with_chunks_and_max_similarity(
+        self, mock_session_cls,
+    ):
+        """retrieve_similar_chunks should expose aggregate diagnostics."""
+        from docmind.library.rag.retriever import retrieve_similar_chunks_with_stats
+
+        chunk = MagicMock()
+        chunk.id = "c1"
+        chunk.document_id = "doc-A"
+        chunk.page_number = 1
+        chunk.content = "hi"
+        chunk.raw_content = "hi"
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(chunk, json.dumps([1.0, 0.0]))]
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session_cls.return_value = mock_session
+
+        stats = await retrieve_similar_chunks_with_stats(
+            query_embedding=[1.0, 0.0],
+            project_id="proj-1",
+            model_name="m",
+            top_k=5,
+            threshold=0.0,
+        )
+
+        assert "chunks" in stats
+        assert "max_similarity" in stats
+        assert "per_document_counts" in stats
+        assert stats["max_similarity"] == pytest.approx(1.0, abs=0.01)
+        assert stats["per_document_counts"] == {"doc-A": 1}
+
+    @pytest.mark.asyncio
+    @patch("docmind.library.rag.retriever.AsyncSessionLocal")
+    async def test_empty_retrieval_returns_zero_max_similarity(
+        self, mock_session_cls,
+    ):
+        from docmind.library.rag.retriever import retrieve_similar_chunks_with_stats
+
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+
+        mock_session = AsyncMock()
+        mock_session.execute.return_value = mock_result
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session_cls.return_value = mock_session
+
+        stats = await retrieve_similar_chunks_with_stats(
+            query_embedding=[1.0, 0.0],
+            project_id="proj-empty",
+            model_name="m",
+            top_k=5,
+            threshold=0.0,
+        )
+
+        assert stats["chunks"] == []
+        assert stats["max_similarity"] == 0.0
+        assert stats["per_document_counts"] == {}

--- a/backend/tests/unit/modules/projects/test_project_chat.py
+++ b/backend/tests/unit/modules/projects/test_project_chat.py
@@ -1,0 +1,297 @@
+"""Unit tests for ProjectChatUseCase grounded refusal (issue #105).
+
+Focus: the chat stream must return a deterministic refusal without calling
+the VLM when retrieval is empty or when the best match is below the
+`RAG_REFUSAL_THRESHOLD`.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from docmind.modules.projects.usecases.project_chat import ProjectChatUseCase
+
+
+PROJECT_ID = "proj-1"
+USER_ID = "user-1"
+CONV_ID = "conv-1"
+
+
+@pytest.fixture
+def mock_repo():
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=MagicMock(
+        id=PROJECT_ID, user_id=USER_ID, persona_id=None,
+    ))
+    repo.list_documents = AsyncMock(return_value=[])
+    return repo
+
+
+@pytest.fixture
+def mock_conv_repo():
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=MagicMock(id=CONV_ID))
+    repo.list_messages = AsyncMock(return_value=[])
+    repo.list_messages_for_conversation = AsyncMock(return_value=[])
+    repo.get_conversation_by_id = AsyncMock(return_value=MagicMock(id=CONV_ID))
+    repo.add_message = AsyncMock()
+    repo.create = AsyncMock(return_value=MagicMock(id=CONV_ID))
+    repo.create_conversation = AsyncMock(return_value=MagicMock(id=CONV_ID))
+    return repo
+
+
+@pytest.fixture
+def mock_rag_service_empty():
+    service = MagicMock()
+    service.embed_query = AsyncMock(return_value=[0.1, 0.2])
+    service.rewrite_query = AsyncMock(return_value="")
+    service.retrieve_chunks = AsyncMock(return_value=[])
+    service.retrieve_chunks_with_stats = AsyncMock(
+        return_value={"chunks": [], "max_similarity": 0.0, "per_document_counts": {}}
+    )
+    return service
+
+
+@pytest.fixture
+def mock_rag_service_weak():
+    """Retrieval returns chunks but similarity is below the refusal threshold."""
+    service = MagicMock()
+    service.embed_query = AsyncMock(return_value=[0.1, 0.2])
+    service.rewrite_query = AsyncMock(return_value="")
+    chunks = [
+        {
+            "chunk_id": "c1",
+            "document_id": "doc-A",
+            "page_number": 1,
+            "content": "unrelated content",
+            "similarity": 0.05,
+        },
+    ]
+    service.retrieve_chunks = AsyncMock(return_value=chunks)
+    service.retrieve_chunks_with_stats = AsyncMock(
+        return_value={
+            "chunks": chunks,
+            "max_similarity": 0.05,
+            "per_document_counts": {"doc-A": 1},
+        },
+    )
+    return service
+
+
+@pytest.fixture
+def mock_vlm_service():
+    service = MagicMock()
+
+    async def _never_call(*_a, **_kw):
+        if False:
+            yield {}
+        raise AssertionError("VLM must not be called when refusing")
+
+    service.stream_chat = _never_call
+    return service
+
+
+@pytest.fixture
+def mock_persona_repo():
+    repo = MagicMock()
+    repo.get_by_id = AsyncMock(return_value=None)
+    return repo
+
+
+async def _collect(stream) -> list[str]:
+    return [evt async for evt in stream]
+
+
+def _parse_sse(event: str) -> tuple[str, dict]:
+    """Return (event_name, payload_dict) from an SSE string.
+
+    The usecase emits events as ``data: {"event": NAME, ...fields}\\n\\n``.
+    """
+    for line in event.splitlines():
+        if line.startswith("data: "):
+            payload = json.loads(line[len("data: "):])
+            return payload.get("event", ""), payload
+    return "", {}
+
+
+class TestEmptyRetrievalRefusal:
+    """When retrieval returns zero chunks, yield grounded refusal without VLM."""
+
+    @pytest.mark.asyncio
+    async def test_refuses_and_does_not_call_vlm(
+        self,
+        mock_repo,
+        mock_conv_repo,
+        mock_rag_service_empty,
+        mock_vlm_service,
+        mock_persona_repo,
+    ):
+        usecase = ProjectChatUseCase(
+            repo=mock_repo,
+            conv_repo=mock_conv_repo,
+            rag_service=mock_rag_service_empty,
+            vlm_service=mock_vlm_service,
+            persona_repo=mock_persona_repo,
+        )
+
+        events = await _collect(
+            usecase.project_chat_stream(
+                project_id=PROJECT_ID,
+                user_id=USER_ID,
+                message="What is the weather today?",
+                conversation_id=CONV_ID,
+            )
+        )
+
+        answer_events = [e for e in events if '"event": "answer"' in e]
+        assert answer_events, "Expected an answer SSE event"
+        _, payload = _parse_sse(answer_events[-1])
+        assert payload.get("refusal") is True, (
+            f"Expected refusal flag in answer payload; got {payload}"
+        )
+        assert "cannot find" in payload["content"].lower() or (
+            "tidak menemukan" in payload["content"].lower()
+        )
+
+    @pytest.mark.asyncio
+    async def test_indonesian_message_gets_indonesian_refusal(
+        self,
+        mock_repo,
+        mock_conv_repo,
+        mock_rag_service_empty,
+        mock_vlm_service,
+        mock_persona_repo,
+    ):
+        usecase = ProjectChatUseCase(
+            repo=mock_repo,
+            conv_repo=mock_conv_repo,
+            rag_service=mock_rag_service_empty,
+            vlm_service=mock_vlm_service,
+            persona_repo=mock_persona_repo,
+        )
+
+        events = await _collect(
+            usecase.project_chat_stream(
+                project_id=PROJECT_ID,
+                user_id=USER_ID,
+                message="Apa yang ada di dokumen ini?",
+                conversation_id=CONV_ID,
+            )
+        )
+
+        answer_events = [e for e in events if '"event": "answer"' in e]
+        _, payload = _parse_sse(answer_events[-1])
+        assert "tidak menemukan" in payload["content"].lower(), (
+            f"Expected Indonesian refusal; got {payload.get('content')!r}"
+        )
+
+
+class TestStrongMatchCallsVLM:
+    """Regression guard: when similarity is above threshold, stream via VLM."""
+
+    @pytest.fixture
+    def mock_rag_service_strong(self):
+        service = MagicMock()
+        service.embed_query = AsyncMock(return_value=[0.1, 0.2])
+        service.rewrite_query = AsyncMock(return_value="")
+        chunks = [
+            {
+                "chunk_id": "c1",
+                "document_id": "doc-A",
+                "page_number": 1,
+                "content": "Invoice total is $500.",
+                "similarity": 0.88,
+            },
+        ]
+        service.retrieve_chunks = AsyncMock(return_value=chunks)
+        service.retrieve_chunks_with_stats = AsyncMock(
+            return_value={
+                "chunks": chunks,
+                "max_similarity": 0.88,
+                "per_document_counts": {"doc-A": 1},
+            },
+        )
+        return service
+
+    @pytest.fixture
+    def mock_vlm_service_streaming(self):
+        """Yields a short streamed answer."""
+        service = MagicMock()
+
+        async def _stream(*_a, **_kw):
+            yield {"type": "answer", "content": "Total is $500."}
+            yield {"type": "done"}
+
+        service.stream_chat = _stream
+        return service
+
+    @pytest.mark.asyncio
+    async def test_vlm_is_called_and_answer_has_no_refusal_flag(
+        self,
+        mock_repo,
+        mock_conv_repo,
+        mock_rag_service_strong,
+        mock_vlm_service_streaming,
+        mock_persona_repo,
+    ):
+        usecase = ProjectChatUseCase(
+            repo=mock_repo,
+            conv_repo=mock_conv_repo,
+            rag_service=mock_rag_service_strong,
+            vlm_service=mock_vlm_service_streaming,
+            persona_repo=mock_persona_repo,
+        )
+
+        events = await _collect(
+            usecase.project_chat_stream(
+                project_id=PROJECT_ID,
+                user_id=USER_ID,
+                message="What is the invoice total?",
+                conversation_id=CONV_ID,
+            )
+        )
+
+        answer_events = [e for e in events if '"event": "answer"' in e]
+        assert answer_events, "Expected an answer event"
+        _, payload = _parse_sse(answer_events[-1])
+        assert payload.get("refusal") is not True, (
+            f"Expected non-refusal answer; got {payload}"
+        )
+        assert payload.get("content") == "Total is $500."
+        assert payload.get("citations"), "Citations must be present on strong-match answers"
+
+
+class TestBelowThresholdRefusal:
+    """Weak retrieval (max_similarity below threshold) also triggers refusal."""
+
+    @pytest.mark.asyncio
+    async def test_refuses_on_weak_match(
+        self,
+        mock_repo,
+        mock_conv_repo,
+        mock_rag_service_weak,
+        mock_vlm_service,
+        mock_persona_repo,
+    ):
+        usecase = ProjectChatUseCase(
+            repo=mock_repo,
+            conv_repo=mock_conv_repo,
+            rag_service=mock_rag_service_weak,
+            vlm_service=mock_vlm_service,
+            persona_repo=mock_persona_repo,
+        )
+
+        events = await _collect(
+            usecase.project_chat_stream(
+                project_id=PROJECT_ID,
+                user_id=USER_ID,
+                message="Off-topic question",
+                conversation_id=CONV_ID,
+            )
+        )
+
+        answer_events = [e for e in events if '"event": "answer"' in e]
+        _, payload = _parse_sse(answer_events[-1])
+        assert payload.get("refusal") is True
+        assert payload.get("max_similarity") == pytest.approx(0.05, abs=0.01)

--- a/frontend/src/components/project/ProjectChatPanel.tsx
+++ b/frontend/src/components/project/ProjectChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
-import { Send, Loader2, User, Bot, FileText, Brain, ChevronDown, ChevronUp, X } from "lucide-react";
+import { Send, Loader2, User, Bot, FileText, Brain, ChevronDown, ChevronUp, X, Info } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { sendProjectChat } from "@/lib/api";
@@ -9,6 +9,7 @@ import type { MessageResponse, ProjectDocumentResponse } from "@/types/api";
 
 interface Citation {
   source_index: number;
+  chunk_id?: string;
   document_id: string;
   page_number: number;
   content_preview: string;
@@ -106,6 +107,7 @@ export function ProjectChatPanel({ projectId, activeConversationId, onConversati
     let answer = "";
     let thinking = "";
     let citations: Citation[] = [];
+    let isRefusal = false;
 
     sendProjectChat(
       projectId,
@@ -155,6 +157,9 @@ export function ProjectChatPanel({ projectId, activeConversationId, onConversati
               answer = (event.content as string) ?? "";
               setStreamingContent(answer);
             }
+            if (event.refusal === true) {
+              isRefusal = true;
+            }
             break;
 
           case "citations":
@@ -203,7 +208,8 @@ export function ProjectChatPanel({ projectId, activeConversationId, onConversati
               citations: citations.length > 0 ? JSON.stringify(citations) : null,
               created_at: new Date().toISOString(),
               _thinking: thinking || undefined,
-            } as MessageResponse & { _thinking?: string },
+              _refusal: isRefusal || undefined,
+            } as MessageResponse & { _thinking?: string; _refusal?: boolean },
           ]);
         }
         setStreamingContent("");
@@ -465,6 +471,12 @@ function CitationTag({ citation, docMap }: { citation: Citation; docMap: DocMap 
 
 function MessageBubble({ message, thinking, docMap }: { message: MessageResponse; thinking?: string; docMap: DocMap }) {
   const isUser = message.role === "user";
+  const isRefusal =
+    !isUser &&
+    ((message as unknown as { _refusal?: boolean })._refusal === true ||
+      /^(I cannot find that information|Saya tidak menemukan informasi tersebut)/i.test(
+        message.content,
+      ));
 
   const parsedCitations: Citation[] = (() => {
     if (!message.citations) return [];
@@ -480,22 +492,34 @@ function MessageBubble({ message, thinking, docMap }: { message: MessageResponse
   return (
     <div className={`flex gap-3 ${isUser ? "flex-row-reverse" : ""}`}>
       <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5 ${
-        isUser ? "bg-gray-700" : "bg-indigo-500/20"
+        isUser ? "bg-gray-700" : isRefusal ? "bg-amber-500/15" : "bg-indigo-500/20"
       }`}>
-        {isUser ? <User className="w-4 h-4 text-gray-300" /> : <Bot className="w-4 h-4 text-indigo-400" />}
+        {isUser
+          ? <User className="w-4 h-4 text-gray-300" />
+          : isRefusal
+            ? <Info className="w-4 h-4 text-amber-400" />
+            : <Bot className="w-4 h-4 text-indigo-400" />}
       </div>
       <div className={`max-w-[80%] space-y-2 ${isUser ? "text-right" : ""}`}>
         {/* Thinking (collapsed by default for saved messages) */}
-        {thinking && !isUser && (
+        {thinking && !isUser && !isRefusal && (
           <ThinkingSection content={thinking} isActive={false} />
         )}
 
         {/* Message content */}
-        <div className={`rounded-xl px-4 py-3 ${isUser ? "bg-indigo-600/20 border border-indigo-500/20" : "bg-[#12121a] border border-[#1e1e2e]"}`}>
+        <div
+          className={`rounded-xl px-4 py-3 ${
+            isUser
+              ? "bg-indigo-600/20 border border-indigo-500/20"
+              : isRefusal
+                ? "bg-amber-500/[0.06] border border-amber-500/20"
+                : "bg-[#12121a] border border-[#1e1e2e]"
+          }`}
+        >
           {isUser ? (
             <p className="text-sm text-gray-200 whitespace-pre-wrap leading-relaxed">{message.content}</p>
           ) : (
-            <div className="text-sm text-gray-200 leading-relaxed prose prose-invert prose-sm max-w-none prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-li:my-0.5 prose-strong:text-white prose-code:text-indigo-300 prose-code:bg-[#1a1a2a] prose-code:px-1 prose-code:rounded">
+            <div className={`text-sm leading-relaxed prose prose-invert prose-sm max-w-none prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-li:my-0.5 prose-strong:text-white prose-code:text-indigo-300 prose-code:bg-[#1a1a2a] prose-code:px-1 prose-code:rounded ${isRefusal ? "text-amber-100" : "text-gray-200"}`}>
               <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.content}</ReactMarkdown>
             </div>
           )}


### PR DESCRIPTION
## Summary

Fixes two demo-blocking RAG failure modes reported by the stakeholder for the Kemendagri demo:

1. **Off-source hallucination** — AI could answer even when retrieval returned empty/weak context.
2. **Retrieval diversity bias** (Mas AAN's report) — \"produk ini berasal dari mana?\" with 2 indexed docs only cited one of them because the other doc's chunks never made it into top-K.

Resolves #105.

## Backend
- Retriever now applies per-document diversity on the vector-only path and guarantees every contributing document appears in top-K.
- New `retrieve_similar_chunks_with_stats` returns chunks + `max_similarity` + `per_document_counts`.
- Project chat refuses deterministically without calling the VLM when retrieval is empty or `max_similarity < RAG_REFUSAL_THRESHOLD` (default 0.25). Refusal is returned in the user's language via a simple stopword heuristic (Indonesian/English) and persisted to the conversation.
- System prompt rewritten to demand strict grounding, multi-source enumeration for aggregate questions, and refusal when context lacks the answer. Citations now carry `chunk_id`.
- Config: `RAG_TOP_K` 5 → 10, `RAG_RETRIEVAL_K` 20 → 30, new `RAG_REFUSAL_THRESHOLD = 0.25`.
- Protocols re-aligned with actual service signatures.
- Structured `rag_retrieval_diagnostics` log per query (project_id, chunk_count, max_similarity, per_document_counts).

## Frontend
- `ProjectChatPanel` tracks the `refusal` flag on the `answer` event and renders the assistant bubble with amber `Info` styling (not the standard Bot indigo). Regex fallback handles replayed history from before the flag existed.
- Citation type gained optional `chunk_id`.

## Tests
- 23 new unit tests across retriever, prompt service, language detection, and the project chat usecase (including a happy-path regression test that asserts the VLM IS called when similarity is strong).
- 642 total unit tests pass. Frontend TypeScript clean.

## Deferred
- Playwright E2E — out of scope for this demo. BDD scenarios documented in issue comments.
- BYOK embedding override threading — pre-existing gap, separate issue.

## Test plan
- [x] Backend unit tests
- [x] Frontend TypeScript
- [ ] Manual: upload 2 Polsek reports, ask \"produk berasal dari mana?\" → both cited
- [ ] Manual: ask off-topic question → amber refusal bubble, no VLM call
- [ ] Manual: ask in Indonesian → Indonesian refusal; ask in English → English refusal