### PR TITLE
fix(frontend): refresh chunks + status after upload/reindex

### DIFF
--- a/frontend/src/components/project/ProjectDocumentsPanel.tsx
+++ b/frontend/src/components/project/ProjectDocumentsPanel.tsx
@@ -88,6 +88,7 @@ export function ProjectDocumentsPanel({ projectId, onDocumentClick }: Props) {
 
         updateTask(taskId, { step: "done", stepLabel: "Done", progress: 100 });
         queryClient.invalidateQueries({ queryKey: ["project-documents", projectId] });
+        queryClient.invalidateQueries({ queryKey: ["project-chunks", projectId] });
         queryClient.invalidateQueries({ queryKey: ["projects"] });
         setTimeout(() => removeTask(taskId), 2500);
       } catch (e) {
@@ -124,6 +125,7 @@ export function ProjectDocumentsPanel({ projectId, onDocumentClick }: Props) {
       const result = await resp.json();
       updateTask(taskId, { step: "done", stepLabel: `${result.chunks_created} chunks`, progress: 100 });
       queryClient.invalidateQueries({ queryKey: ["project-documents", projectId] });
+      queryClient.invalidateQueries({ queryKey: ["project-chunks", projectId] });
       setTimeout(() => removeTask(taskId), 2500);
     } catch {
       updateTask(taskId, { step: "error", stepLabel: "Re-index failed", progress: 0 });

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { toast } from "sonner";
 import {
   fetchProjects,
@@ -73,11 +74,36 @@ export function useDeleteProject() {
 }
 
 export function useProjectDocuments(projectId: string) {
-  return useQuery({
+  const qc = useQueryClient();
+  const query = useQuery({
     queryKey: ["project-documents", projectId],
     queryFn: () => fetchProjectDocuments(projectId),
     enabled: !!projectId,
+    // Indexing runs as a background task on the server and there is no push
+    // channel yet. While any document is still processing/uploaded we poll
+    // so the status dot (and the chunks panel below) reflect reality.
+    refetchInterval: (q) => {
+      const data = q.state.data as { status?: string }[] | undefined;
+      if (!data) return false;
+      const hasProcessing = data.some(
+        (d) => d.status === "processing" || d.status === "uploaded",
+      );
+      return hasProcessing ? 3000 : false;
+    },
   });
+
+  // When any document transitions from processing/uploaded to ready, the
+  // chunks list on the Chunks tab needs to refetch to pick up the new rows.
+  const data = query.data;
+  useEffect(() => {
+    if (!data) return;
+    const anyReady = data.some((d) => d.status === "ready");
+    if (anyReady) {
+      qc.invalidateQueries({ queryKey: ["project-chunks", projectId] });
+    }
+  }, [data, projectId, qc]);
+
+  return query;
 }
 
 export function useAddProjectDocument(projectId: string) {


### PR DESCRIPTION
Status dot stayed yellow and the Chunks tab stayed empty after upload because: (a) only the project-documents cache was invalidated on upload success, (b) indexing runs as a background task so the initial response has no useful status, and (c) there was no polling. Now polls documents while any is processing/uploaded and invalidates project-chunks both explicitly on upload/reindex success and on any transition to ready.