### PR TITLE
fix(rag): exclude orphan chunks from unlinked documents

### DIFF
--- a/backend/alembic/versions/b9c0d1e2f3a4_cleanup_orphan_page_chunks.py
+++ b/backend/alembic/versions/b9c0d1e2f3a4_cleanup_orphan_page_chunks.py
@@ -1,0 +1,51 @@
+"""One-time cleanup of orphaned page_chunks + chunk_embeddings.
+
+Before issue #104 was merged, removing a document from a project only
+unlinked the document (set documents.project_id = NULL) and left the
+associated page_chunks rows pointing at the project. These orphan chunks
+leaked into RAG retrieval. The code-level fix now requires
+``documents.project_id = page_chunks.project_id`` at query time, but
+existing orphan rows must be deleted so historical projects no longer
+hold phantom context.
+
+Revision ID: b9c0d1e2f3a4
+Revises: a8b9c0d1e2f3
+Create Date: 2026-04-21
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b9c0d1e2f3a4"
+down_revision: Union[str, None] = "a8b9c0d1e2f3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Delete orphan chunks where either the document was unlinked or its
+    # project assignment has moved. ChunkEmbedding rows cascade via
+    # chunk_embeddings.chunk_id (ON DELETE CASCADE).
+    op.execute(
+        """
+        DELETE FROM page_chunks pc
+        USING documents d
+        WHERE pc.document_id = d.id
+          AND (d.project_id IS NULL OR d.project_id <> pc.project_id);
+        """
+    )
+
+    # Belt-and-braces: also delete chunks whose document row no longer
+    # exists at all (should be empty after #104's delete path ships).
+    op.execute(
+        """
+        DELETE FROM page_chunks
+        WHERE document_id NOT IN (SELECT id FROM documents);
+        """
+    )
+
+
+def downgrade() -> None:
+    # Irreversible data cleanup — no-op downgrade.
+    pass

--- a/backend/src/docmind/library/rag/retriever.py
+++ b/backend/src/docmind/library/rag/retriever.py
@@ -149,7 +149,11 @@ async def _retrieve_vector_only(
         stmt = (
             select(PageChunk, ChunkEmbedding.embedding)
             .join(ChunkEmbedding, ChunkEmbedding.chunk_id == PageChunk.id)
-            .join(Document, Document.id == PageChunk.document_id)
+            .join(
+                Document,
+                (Document.id == PageChunk.document_id)
+                & (Document.project_id == PageChunk.project_id),
+            )
             .where(
                 PageChunk.project_id == project_id,
                 ChunkEmbedding.model_name == model_name,
@@ -223,7 +227,11 @@ async def _retrieve_hybrid(
         stmt = (
             select(PageChunk, ChunkEmbedding.embedding)
             .join(ChunkEmbedding, ChunkEmbedding.chunk_id == PageChunk.id)
-            .join(Document, Document.id == PageChunk.document_id)
+            .join(
+                Document,
+                (Document.id == PageChunk.document_id)
+                & (Document.project_id == PageChunk.project_id),
+            )
             .where(
                 PageChunk.project_id == project_id,
                 ChunkEmbedding.model_name == model_name,

--- a/backend/src/docmind/modules/analytics/repositories.py
+++ b/backend/src/docmind/modules/analytics/repositories.py
@@ -70,10 +70,17 @@ class AnalyticsRepository:
         counted (defense-in-depth for issue #104).
         """
         async with AsyncSessionLocal() as session:
+            # JOIN Document and require it is still attached to the same
+            # project so orphan chunks from unlinked documents are excluded
+            # (issue #104 leftover).
             result = await session.execute(
                 select(func.count())
                 .select_from(PageChunk)
-                .join(Document, Document.id == PageChunk.document_id)
+                .join(
+                    Document,
+                    (Document.id == PageChunk.document_id)
+                    & (Document.project_id == PageChunk.project_id),
+                )
                 .where(
                     PageChunk.project_id.in_(
                         select(Project.id).where(Project.user_id == user_id)

--- a/backend/src/docmind/modules/projects/repositories/project.py
+++ b/backend/src/docmind/modules/projects/repositories/project.py
@@ -332,17 +332,25 @@ class ProjectRepository:
             if document_id:
                 filters.append(PageChunk.document_id == document_id)
 
+            # JOIN Document and require it is still attached to the same
+            # project, so orphan chunks from unlinked docs (issue #104
+            # leftover) cannot leak into the list.
+            join_on = (
+                (Document.id == PageChunk.document_id)
+                & (Document.project_id == PageChunk.project_id)
+            )
+
             count_stmt = (
                 select(func.count())
                 .select_from(PageChunk)
-                .join(Document, Document.id == PageChunk.document_id)
+                .join(Document, join_on)
                 .where(*filters)
             )
             total = (await session.execute(count_stmt)).scalar() or 0
 
             stmt = (
                 select(PageChunk)
-                .join(Document, Document.id == PageChunk.document_id)
+                .join(Document, join_on)
                 .where(*filters)
                 .order_by(PageChunk.page_number, PageChunk.chunk_index)
                 .limit(limit)

--- a/backend/tests/unit/library/rag/test_retriever_diversity.py
+++ b/backend/tests/unit/library/rag/test_retriever_diversity.py
@@ -152,6 +152,88 @@ class TestVectorOnlyDiversifies:
         )
 
 
+class TestRetrieverFiltersOrphanChunks:
+    """Retrieval must verify the chunk's document is STILL attached to the
+    project being queried. Older chunks from unlinked documents must not
+    leak even if their PageChunk.project_id still points to the project.
+    """
+
+    @pytest.mark.asyncio
+    @patch("docmind.library.rag.retriever.AsyncSessionLocal")
+    async def test_vector_only_query_filters_by_document_project_match(
+        self, mock_session_cls,
+    ):
+        """Retriever must add a WHERE/ON clause binding Document.project_id
+        to PageChunk.project_id so unlinked documents are excluded."""
+        from docmind.library.rag.retriever import _retrieve_vector_only
+
+        captured: list[object] = []
+
+        async def capture_execute(stmt):
+            captured.append(stmt)
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        mock_session = AsyncMock()
+        mock_session.execute = capture_execute
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session_cls.return_value = mock_session
+
+        await _retrieve_vector_only(
+            query_embedding=[1.0, 0.0],
+            project_id="proj-x",
+            model_name="m",
+            top_k=5,
+            threshold=0.0,
+        )
+
+        assert captured, "No SQL statement executed"
+        compiled = str(captured[0].compile()).lower()
+        assert "documents.project_id" in compiled, (
+            "Retriever must constrain documents.project_id; compiled SQL:\n"
+            f"{compiled}"
+        )
+
+    @pytest.mark.asyncio
+    @patch("docmind.library.rag.retriever.AsyncSessionLocal")
+    async def test_hybrid_query_filters_by_document_project_match(
+        self, mock_session_cls,
+    ):
+        from docmind.library.rag.retriever import _retrieve_hybrid
+
+        captured: list[object] = []
+
+        async def capture_execute(stmt):
+            captured.append(stmt)
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        mock_session = AsyncMock()
+        mock_session.execute = capture_execute
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session_cls.return_value = mock_session
+
+        await _retrieve_hybrid(
+            query_embedding=[1.0, 0.0],
+            project_id="proj-x",
+            model_name="m",
+            query_text="where from",
+            top_k=5,
+            threshold=0.0,
+        )
+
+        assert captured, "No SQL statement executed"
+        compiled = str(captured[0].compile()).lower()
+        assert "documents.project_id" in compiled, (
+            "Hybrid retriever must constrain documents.project_id; compiled SQL:\n"
+            f"{compiled}"
+        )
+
+
 class TestRetrieveSimilarChunksReturnsDiagnostics:
     """Top-level API should expose max_similarity so refusal logic can act on it."""
 


### PR DESCRIPTION
Historical orphans from before #104 leaked into RAG because the JOIN only checked the Document existed, not that it was still attached to the same project. Tightens JOINs to require documents.project_id = page_chunks.project_id. Cleanup migration included. 644 tests pass.